### PR TITLE
New Features: Open Source OpenMM relaxing and antigen trimming for memory efficiency. 

### DIFF
--- a/IgGM/deploy/ab_design.py
+++ b/IgGM/deploy/ab_design.py
@@ -101,7 +101,7 @@ class AbDesigner(BaseDesigner):
         outputs = self.forward(inputs, *args, **kwargs)
         return inputs, outputs
 
-    def infer_pdb(self, chains, filename, relax=False, task='design', *args, **kwargs):
+    def infer_pdb(self, chains, filename, relax=False, relax_open=False, task='design', *args, **kwargs):
         inputs, outputs = self.infer(chains, task, *args, **kwargs)
         complex_id = inputs["base"]["complex_id"]
         raw_seqs = {}
@@ -110,8 +110,8 @@ class AbDesigner(BaseDesigner):
             raw_seqs[chain_id] = raw_seq
 
         self._output_to_fasta(inputs, outputs, filename[:-4] + ".fasta")
-        if task == 'design' or task == 'fr_design':
-            self._output_to_pdb(inputs, outputs, filename, relax=relax)
+        if task == 'design' or task == 'fr_design' or task == 'affinity_maturation':
+            self._output_to_pdb(inputs, outputs, filename, relax=relax, relax_open=relax_open)
 
     def __sample_cm_ss2ss(self, prot_data_curr, idx_step, inputs_addi, chunk_size=None, temperature=1.0):
         """Sample amino-acid sequences & backbone structures w/ CM."""

--- a/IgGM/deploy/base_designer.py
+++ b/IgGM/deploy/base_designer.py
@@ -13,7 +13,7 @@ from IgGM.protein.data_transform import get_asym_ids
 from IgGM.protein.parser import PdbParser
 from IgGM.protein.prot_constants import RESD_NAMES_1C, N_ATOMS_PER_RESD
 from IgGM.protein.utils import init_qta_params
-from IgGM.utils import calc_trsl_vec, get_tmp_dpath, Rosetta_relax
+from IgGM.utils import calc_trsl_vec, get_tmp_dpath, Rosetta_relax, OpenMM_relax
 
 
 class BaseDesigner(BaseModel):
@@ -214,7 +214,7 @@ class BaseDesigner(BaseModel):
         export_fasta(sequences, ids=ids, output=filename)
 
     @staticmethod
-    def _output_to_pdb(inputs, outputs, filename, relax=False):
+    def _output_to_pdb(inputs, outputs, filename, relax=False, relax_open=False):
         """Build a dict of protein structure data."""
         pred_info = 'REMARK 250 Structure predicted by IgGM\n'
         ligand_id = inputs["base"]["ligand_id"]
@@ -264,12 +264,19 @@ class BaseDesigner(BaseModel):
         PdbParser.save_multimer(prot_data, filename, pred_info=pred_info)
         # remove the tmp directory tmp_path
         shutil.rmtree(tmp_path)
-        if relax:
-            try:
-                Rosetta_relax(filename)
-            except Exception as e:
-                logging.error(f'Error during Rosetta relaxation: {e}')
-                logging.info('Relaxation failed, skipping...')
+        if relax or relax_open:
+            if relax:
+                try:
+                    Rosetta_relax(filename)
+                except Exception as e:
+                    logging.error(f'Error during Rosetta relaxation: {e}')
+                    logging.info('Relaxation failed, skipping...')
+            elif relax_open:
+                try:
+                    OpenMM_relax(filename)
+                except Exception as e:
+                    logging.error(f'Error during OpenMM relaxation: {e}')
+                    logging.info('Relaxation failed, skipping...')
 
         logging.info(f'PDB file generated: {filename}')
 

--- a/IgGM/utils/__init__.py
+++ b/IgGM/utils/__init__.py
@@ -6,18 +6,23 @@ from .registry import Registry
 from .file import jload, jdump, get_tmp_dpath, download_file
 from .env import seed_all_rng, setup_logger, setup
 from .diff_util import ss2ptr, ptr2ss, so3_scale, intp_prob_mat_dsct, intp_trsl_mat, intp_rota_tns, IsotropicGaussianSO3, IGSO3Buffer, rota2quat, replace_with_mask, calc_trsl_vec
+from .openmm_relax import OpenMM_relax
 
 # Relax the input pdb file
 def Rosetta_relax(pdb_file):
     import os
-    import pyrosetta
-    pyrosetta.init()
-    from pyrosetta.rosetta.core.select import residue_selector as selections
-    from pyrosetta import pose_from_pdb, create_score_function
-    from pyrosetta.rosetta.core.pack.task import TaskFactory, operation
-    from pyrosetta.rosetta.core.select.movemap import MoveMapFactory, move_map_action
-    from pyrosetta.rosetta.protocols.minimization_packing import PackRotamersMover
-    from pyrosetta.rosetta.protocols.relax import FastRelax
+    try:
+        import pyrosetta
+        pyrosetta.init()
+        from pyrosetta.rosetta.core.select import residue_selector as selections
+        from pyrosetta import pose_from_pdb, create_score_function
+        from pyrosetta.rosetta.core.pack.task import TaskFactory, operation
+        from pyrosetta.rosetta.core.select.movemap import MoveMapFactory, move_map_action
+        from pyrosetta.rosetta.protocols.minimization_packing import PackRotamersMover
+        from pyrosetta.rosetta.protocols.relax import FastRelax
+    except ImportError:
+        print("❌ PyRosetta not found. Please install via `pip install pyrosetta-installer` and setup, or use --relax_open for OpenMM.")
+        return
 
     print(f'Rosetta processing {pdb_file} for Relax')
 

--- a/IgGM/utils/__init__.py
+++ b/IgGM/utils/__init__.py
@@ -21,7 +21,7 @@ def Rosetta_relax(pdb_file):
         from pyrosetta.rosetta.protocols.minimization_packing import PackRotamersMover
         from pyrosetta.rosetta.protocols.relax import FastRelax
     except ImportError:
-        print("❌ PyRosetta not found. Please install via `pip install pyrosetta-installer` and setup, or use --relax_open for OpenMM.")
+        print("[ERROR] PyRosetta not found. Please install via `pip install pyrosetta-installer` and setup, or use --relax_open for OpenMM.")
         return
 
     print(f'Rosetta processing {pdb_file} for Relax')

--- a/IgGM/utils/openmm_relax.py
+++ b/IgGM/utils/openmm_relax.py
@@ -1,0 +1,123 @@
+import os
+import sys
+import tempfile
+
+def OpenMM_relax(pdb_file):
+    """
+    Relaxes a PDB structure using OpenMM and PDBFixer.
+    Replaces the proprietary PyRosetta relaxation.
+    
+    Strategy:
+    1. Fix residues/atoms with PDBFixer.
+    2. Remove Heterogens (Ligands/Water) to ensure Amber14 compatibility.
+    3. Save to temp PDB and STRIP CONECTs to clean topology.
+    4. Reload, Add Hydrogens (Modeller), Minimize.
+    """
+    print(f"🧬 OpenMM processing {pdb_file} for Relax")
+    
+    try:
+        from pdbfixer import PDBFixer
+        from openmm.app import PDBFile, Modeller, ForceField, Simulation, PME, HBonds, NoCutoff
+        from openmm import LangevinIntegrator, unit, Platform
+    except ImportError:
+        print("❌ OpenMM or PDBFixer not found. Please install them via conda: `conda install -c conda-forge openmm pdbfixer`")
+        return
+
+    # 1. Load and Fix PDB
+    try:
+        print("   Initializing PDBFixer...")
+        fixer = PDBFixer(filename=pdb_file)
+        
+        print("   Removing heterogens (ligands/water)...")
+        fixer.removeHeterogens(keepWater=False)
+        
+        print("   Fixing topology (missing residues/atoms)...")
+        fixer.findMissingResidues()
+        fixer.findMissingAtoms()
+        fixer.addMissingAtoms()
+        # skip fixer.addMissingHydrogens - we use Modeller later
+    except Exception as e:
+        print(f"   ❌ Error validating/fixing PDB: {e}")
+        return
+
+    # 2. Save Intermediate and Strip CONECTs
+    print("   Stripping bad CONECT records...")
+    temp_fd, temp_path = tempfile.mkstemp(suffix=".pdb")
+    os.close(temp_fd)
+    
+    try:
+        # Write fixed PDB to temp
+        with open(temp_path, 'w') as f:
+            PDBFile.writeFile(fixer.topology, fixer.positions, f)
+            
+        # Read back and strip CONECT lines
+        with open(temp_path, 'r') as f:
+            lines = f.readlines()
+            
+        clean_lines = [line for line in lines if not line.startswith("CONECT")]
+        
+        # Write clean PDB (reusing temp path)
+        with open(temp_path, 'w') as f:
+            f.writelines(clean_lines)
+            
+        # 3. Reload Clean PDB
+        print("   Reloading clean topology...")
+        pdb = PDBFile(temp_path)
+        
+    except Exception as e:
+        print(f"   ❌ Error in Strip-CONECT step: {e}")
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+        return
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+    # 4. Setup Modeller and ForceField
+    try:
+        # Standard choice: amber14-all.xml and implicit solvent like implicit/gbn2.xml
+        forcefield = ForceField('amber14-all.xml', 'implicit/gbn2.xml')
+        
+        modeller = Modeller(pdb.topology, pdb.positions)
+        
+        # 5. Add Hydrogens using ForceField
+        print("   Adding hydrogens...")
+        modeller.addHydrogens(forcefield)
+        
+        # 6. Create System
+        system = forcefield.createSystem(modeller.topology, nonbondedMethod=NoCutoff, 
+                                         constraints=HBonds)
+        
+        # Integrator
+        integrator = LangevinIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds)
+        
+        # Platform
+        try:
+            platform = Platform.getPlatformByName('CUDA')
+            prop = {'CudaPrecision': 'mixed'}
+        except Exception:
+            try:
+                platform = Platform.getPlatformByName('OpenCL')
+                prop = {}
+            except:
+                platform = Platform.getPlatformByName('CPU')
+                prop = {}
+            
+        print(f"   Using platform: {platform.getName()}")
+
+        simulation = Simulation(modeller.topology, system, integrator, platform, prop)
+        simulation.context.setPositions(modeller.positions)
+
+        # 7. Minimize Energy
+        print("   Minimizing energy...")
+        simulation.minimizeEnergy()
+        
+        # 8. Save Relaxed PDB
+        state = simulation.context.getState(getPositions=True)
+        with open(pdb_file, 'w') as f:
+            PDBFile.writeFile(simulation.topology, state.getPositions(), f)
+            
+        print(f"✅ OpenMM relaxed PDB saved to: {pdb_file}")
+        
+    except Exception as e:
+        print(f"   ❌ OpenMM Relax failed: {e}")

--- a/IgGM/utils/openmm_relax.py
+++ b/IgGM/utils/openmm_relax.py
@@ -13,14 +13,14 @@ def OpenMM_relax(pdb_file):
     3. Save to temp PDB and STRIP CONECTs to clean topology.
     4. Reload, Add Hydrogens (Modeller), Minimize.
     """
-    print(f"🧬 OpenMM processing {pdb_file} for Relax")
+    print(f"[OpenMM] Processing {pdb_file} for Relax")
     
     try:
         from pdbfixer import PDBFixer
         from openmm.app import PDBFile, Modeller, ForceField, Simulation, PME, HBonds, NoCutoff
         from openmm import LangevinIntegrator, unit, Platform
     except ImportError:
-        print("❌ OpenMM or PDBFixer not found. Please install them via conda: `conda install -c conda-forge openmm pdbfixer`")
+        print("[ERROR] OpenMM or PDBFixer not found. Please install them via conda: `conda install -c conda-forge openmm pdbfixer`")
         return
 
     # 1. Load and Fix PDB
@@ -37,7 +37,7 @@ def OpenMM_relax(pdb_file):
         fixer.addMissingAtoms()
         # skip fixer.addMissingHydrogens - we use Modeller later
     except Exception as e:
-        print(f"   ❌ Error validating/fixing PDB: {e}")
+        print(f"   [ERROR] Error validating/fixing PDB: {e}")
         return
 
     # 2. Save Intermediate and Strip CONECTs
@@ -65,7 +65,7 @@ def OpenMM_relax(pdb_file):
         pdb = PDBFile(temp_path)
         
     except Exception as e:
-        print(f"   ❌ Error in Strip-CONECT step: {e}")
+        print(f"   [ERROR] Error in Strip-CONECT step: {e}")
         if os.path.exists(temp_path):
             os.remove(temp_path)
         return
@@ -109,15 +109,21 @@ def OpenMM_relax(pdb_file):
         simulation.context.setPositions(modeller.positions)
 
         # 7. Minimize Energy
+        state0 = simulation.context.getState(getEnergy=True)
+        e0 = state0.getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+        print(f"   Initial Energy: {e0:.2f} kJ/mol")
+
         print("   Minimizing energy...")
         simulation.minimizeEnergy()
         
         # 8. Save Relaxed PDB
-        state = simulation.context.getState(getPositions=True)
+        state = simulation.context.getState(getPositions=True, getEnergy=True)
+        e1 = state.getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
+        print(f"   Final Energy:   {e1:.2f} kJ/mol")
         with open(pdb_file, 'w') as f:
             PDBFile.writeFile(simulation.topology, state.getPositions(), f)
             
-        print(f"✅ OpenMM relaxed PDB saved to: {pdb_file}")
+        print(f"[SUCCESS] OpenMM relaxed PDB saved to: {pdb_file}")
         
     except Exception as e:
-        print(f"   ❌ OpenMM Relax failed: {e}")
+        print(f"   [ERROR] OpenMM Relax failed: {e}")

--- a/IgGM/utils/registry.py
+++ b/IgGM/utils/registry.py
@@ -27,7 +27,7 @@ def get_registry(name):
 
 class Registry(dict):
     """
-    registry helper，
+    registry helper,
     Eg. creeting a registry:
         some_registry = Registry({'default': default_module})
 

--- a/README-es.md
+++ b/README-es.md
@@ -1,0 +1,282 @@
+<div align="center">
+
+# Un Modelo Fundacional Generativo para el Diseño de Anticuerpos
+
+[![Homepage](http://img.shields.io/badge/Homepage-IgGM-ff88dd.svg)](https://iggm.rubo.wang)
+[![Journal Paper](http://img.shields.io/badge/Journal_paper-biorxiv-FFA876.svg)](https://www.biorxiv.org/content/10.1101/2025.09.12.675771)
+[![Conference Paper](http://img.shields.io/badge/Conference_paper-ICLR2025-6B77FE.svg)](https://openreview.net/forum?id=zmmfsJpYcq)
+[![Code License](https://img.shields.io/badge/Code%20License-MIT-green.svg)](https://github.com/TencentAI4S/IgGM/blob/master/LICENSE)
+
+
+![header](docs/IgGM_dynamic.gif)
+
+</div>
+
+
+--------------------------------------------------------------------------------
+[English](./README.md) | [简体中文](./README-zh.md) | Español | [Português](./README-pt.md)
+
+## 🔊Noticias
+
+* **2025-08-22**: ¡Acabamos de enterarnos de que nuestro uso de IgGM en la competencia de diseño de anticuerpos ([AIntibody: an experimentally validated in silico antibody discovery design challenge](https://www.nature.com/articles/s41587-024-02469-9)) nos ha ganado un premio entre los tres primeros! 🎉
+* **2025-08-21**: IgGM se actualiza a un modelo fundacional generativo para el diseño de anticuerpos, admitiendo tareas como el diseño de nuevos anticuerpos, maduración de afinidad, diseño inverso, predicción de estructuras y humanización.
+* **2025-01-15**: IgGM es aceptado en ICLR 2025, con el artículo titulado "IgGM: A Generative Model for Functional Antibody and Nanobody Design"🎉
+
+## 📘Introducción
+
+Este repositorio contiene la implementación de los dos artículos siguientes:
+
+El artículo de ICLR 2025, "IgGM: A Generative Model for Functional Antibody and Nanobody Design," introduce IgGM, un modelo que puede diseñar la estructura general y las secuencias de la región CDR basándose en una secuencia marco dada, y también puede diseñar anticuerpos para epítopos específicos.
+
+"A Generative Foundation Model for Antibody Design" extiende aún más las capacidades de IgGM a un modelo fundacional generativo para el diseño de anticuerpos, permitiendo tareas como el diseño de novo de anticuerpos, maduración de afinidad, diseño inverso, predicción de estructuras y humanización.
+
+Si tiene alguna pregunta, comuníquese con el equipo de IgGM en wangrubo@hotmail.com, wufandi@outlook.com.
+
+## 🧑🏻‍💻Comenzando
+
+###
+1. Clonar el paquete
+```shell
+git clone https://github.com/TencentAI4S/IgGM.git
+cd IgGM
+```
+
+2. Instalar el entorno
+
+```shell
+conda env create -n IgGM -f environment.yaml
+conda activate IgGM
+pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.0.1+cu117.html
+```
+**Opcional:** 
+
+Si necesita usar relax para la salida, instale la siguiente versión de PyRosetta:
+
+```shell
+pip install https://west.rosettacommons.org/pyrosetta/release/release/PyRosetta4.Release.python310.ubuntu.wheel/pyrosetta-2025.37+release.df75a9c48e-cp310-cp310-linux_x86_64.whl
+```
+Alternativamente, puede usar OpenMM para la relajación, que está incluido en environment.yaml. Use el argumento `--relax_open`.
+
+3. Descargar el modelo (Opcional, los pesos preentrenados se descargarán automáticamente cuando se ejecute el código)
+    * [Zenodo](https://zenodo.org/records/16909543)
+
+
+**Nota**:
+
+Si descarga los pesos en la carpeta `./checkpoints`, puede ejecutar el código subsecuente directamente.
+
+Si no descarga los pesos, se descargarán automáticamente cuando ejecute el código.
+
+## 📖Ejemplos
+
+Puede usar un archivo fasta como entrada de secuencia y un archivo pdb como entrada de antígeno. Los archivos de ejemplo se encuentran en la carpeta `examples`.
+
+* **Una versión de Colab de IgGM mantenida por Luis se puede encontrar en [Colab-IgGM](https://github.com/Lefrunila/Colab-IgGM), ¡gracias a Luis por sus contribuciones!**
+
+* **Opcional:**
+  * Para todos los comandos, puede usar PyRosetta para relajar la salida agregando `--relax` o `-r`. Esta opción también agregará átomos de cadena lateral.
+  * Alternativamente, use `--relax_open` o `-r_open` para usar OpenMM para la relajación de estructuras (no se requiere licencia de PyRosetta).
+  * Para todos los comandos, puede especificar la longitud máxima de truncamiento para el antígeno en 384 para evitar problemas de memoria agregando `--max_antigen_size 384` o `-mas 384`.
+
+Para el procesamiento posterior, necesita preparar un archivo fasta y un archivo pdb. Su archivo fasta debe tener la siguiente estructura, la cual puede consultar en la carpeta `examples`.
+
+```
+>H  # ID de cadena pesada
+VQLVESGGGLVQPGGSLRLSCAASXXXXXXXYMNWVRQAPGKGLEWVSVVXXXXXTFYTDSVKGRFTISRDNSKNTLYLQMNSLRAEDTAVYYCARXXXXXXXXXXXXXXWGQGTMVTVSS
+>L # ID de cadena ligera
+DIQMTQSPSSLSASVGDRVSITCXXXXXXXXXXXWYQQKPGKAPKLLISXXXXXXXGVPSRFSGSGSGTDFTLTITSLQPEDFATYYCXXXXXXXXXXXFGGGTKVEIK
+>A # ID del antígeno, debe ser consistente con el archivo pdb
+NLCPFDEVFNATRFASVYAWNRKRISNCVADYSVLYNFAPFFAFKCYGVSPTKLNDLCFTNVYADSFVIRGNEVSQIAPGQTGNIADYNYKLPDDFTGCVIAWNSNKLDSKVGGNYNYRYRLFRKSNLKPFERDISTEIYQAGNKPCNGVAGVNCYFPLQSYGFRPTYGVGHQPYRVVVLSFELLHAPATVCGP
+```
+* 'X' indica la región a diseñar.
+* Para obtener el epítopo del antígeno, puede usar el siguiente comando:
+<a id="calculo-de-epitopo"></a>
+
+```
+python design.py --fasta examples/fasta.files.native/8iv5_A_B_G.fasta --antigen examples/pdb.files.native/8iv5_A_B_G.pdb --cal_epitope
+
+'--antigen' representa la estructura de un complejo conocido, y '--fasta' representa la secuencia de un complejo conocido, lo cual devolverá el formato de epítopo requerido más tarde, y después de copiar, el fasta puede ser reemplazado con la secuencia que necesita diseñar. 
+
+El formato de epítopo generado es (El número de serie comienza en 1): 7 8 9 10 11 12 13 14 108 109 110 111 112 113 114 115 116 118 167 
+
+Si especifica el epítopo según la secuencia, asegúrese de que el orden de la secuencia sea consistente con el orden en el archivo PDB, y marque el número de serie de la posición correspondiente.
+```
+
+#### Ejemplo 1: Usando IgGM para predecir estructuras de anticuerpos y nanoanticuerpos
+* Si el PDB contiene la estructura del complejo, este comando generará automáticamente la información del epítopo. En este caso, puede eliminar `--epitope`.
+```
+# anticuerpo
+python design.py --fasta examples/fasta.files.native/8iv5_A_B_G.fasta --antigen examples/pdb.files.native/8iv5_A_B_G.pdb --epitope 7 8 9 10 11 12 13 14 108 109 110 111 112 113 114 115 116 118 167 157 158 160 161 162 163 164
+
+# nanoanticuerpo
+python design.py --fasta examples/fasta.files.native/8q94_C_NA_A.fasta --antigen examples/pdb.files.native/8q94_C_NA_A.pdb --epitope 109 110 111 112 113 114 115 116 117 120 121 140 141 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 165 166 167
+```
+
+#### Ejemplo 2: Dada la estructura de un complejo, usar IgGM para diseñar la secuencia correspondiente
+* Si el PDB contiene la estructura del complejo, este comando generará automáticamente la información del epítopo. En este caso, puede eliminar `--epitope`.
+```
+# anticuerpo
+python design.py --fasta examples/fasta.files.design/8hpu_M_N_A/8hpu_M_N_A_CDR_H3.fasta --antigen examples/pdb.files.native/8hpu_M_N_A.pdb --epitope 7 8 9 10 11 12 13 14 108 109 110 111 112 113 114 115 116 118 167 157 158 160 161 162 163 164 --run_task inverse_design
+
+# nanoanticuerpo
+python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/8q95_B_NA_A_CDR_H3.fasta --antigen examples/pdb.files.native/8q95_B_NA_A.pdb --epitope 109 110 111 112 113 114 115 116 117 120 121 140 141 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 165 166 167 --run_task inverse_design
+```
+
+#### Ejemplo 3: Usando IgGM para el rediseno de secuencias de la región marco (framework)
+* Aquí tomamos la humanización como ejemplo, que requiere [BioPhi](https://biophi.dichlab.org/humanization/humanize/).
+```
+# Anticuerpo de ratón inicial
+>H
+QVQLQESGPGLVAPSQSLSITCTVSGFSLTGYGVNWVRQPPGKGLEWLGMIWGDGNTDYNSALKSRLSISKDNSKSQVFLKMNSLHTDDTARYYCARERDYRLDYWGQGTTLTVSS
+>L
+DIVLTQSPASLSASVGETVTITCRASGNIHNYLAWYQQKQGKSPQLLVYYTTTLADGVPSRFSGSGSGTQYSLKINSLQPEDFGSYYCQHFWSTPRTFGGGTKLEIK
+>A
+KVFGRCELAAAMKRHGLDNYRGYSLGNWVCAAKFESNFNTQATNRNTDGSTDYGILQINSRWWCNDGRTPGSRNLCNIPCSALLSSDITASVNCAKKIVSDGNGMNAWVAWRNRCKGTDVQAWIRGCRL
+
+# Solo para humanización, use BioPhi para la humanización inicial del anticuerpo de ratón
+>H
+QVQLQESGPGLVKPSETLSLTCTVSGFSLTGYGWGWIRQPPGKGLEWIGSIWGDGNTYYNPSLKSRVTISVDTSKNQFSLKLSSVTAADTAVYYCARERDYRLDYWGQGTLVTVSS
+>L
+DIQLTQSPSFLSASVGDRVTITCRASGNIHNYLAWYQQKPGKAPKLLIYYTTTLQSGVPSRFSGSGSGTEFTLTISSLQPEDFATYYCQHFWSTPRTFGGGTKVEIK
+>A
+KVFGRCELAAAMKRHGLDNYRGYSLGNWVCAAKFESNFNTQATNRNTDGSTDYGILQINSRWWCNDGRTPGSRNLCNIPCSALLSSDITASVNCAKKIVSDGNGMNAWVAWRNRCKGTDVQAWIRGCRL
+
+# Compare las diferencias entre las secuencias humanizadas de diferentes regiones FR y el anticuerpo de ratón para identificar las partes que necesitan optimización. Aquí, se usa FR1 como ejemplo.
+>H
+QVQLQESGPGLVXPSXXLSXTCTVSGFSLTGYGWGWIRQPPGKGLEWIGSIWGDGNTYYNPSLKSRVTISVDTSKNQFSLKLSSVTAADTAVYYCARERDYRLDYWGQGTLVTVSS
+>L
+DIQLTQSPSFLSASVGDRVTITCRASGNIHNYLAWYQQKPGKAPKLLIYYTTTLQSGVPSRFSGSGSGTEFTLTISSLQPEDFATYYCQHFWSTPRTFGGGTKVEIK
+>A
+KVFGRCELAAAMKRHGLDNYRGYSLGNWVCAAKFESNFNTQATNRNTDGSTDYGILQINSRWWCNDGRTPGSRNLCNIPCSALLSSDITASVNCAKKIVSDGNGMNAWVAWRNRCKGTDVQAWIRGCRL
+
+# Use IgGM para diseñar la región FR1
+
+python design.py --fasta examples/humanization/fasta.files.design.heavy_fr1/1vfb_B_A_C.fasta --antigen examples/humanization/pdb.files.native/1vfb_B_A_C.pdb --run_task fr_design
+
+```
+
+#### Ejemplo 4: Usando IgGM para la maduración de afinidad de anticuerpos y nanoanticuerpos contra un antígeno dado.
+```
+# anticuerpo
+python design.py --fasta examples/fasta.files.design/8hpu_M_N_A/8hpu_M_N_A_CDR_H3.fasta --antigen examples/pdb.files.native/8hpu_M_N_A.pdb --fasta_origin examples/fasta.files.native/8hpu_M_N_A.fasta --run_task affinity_maturation --num_samples 100
+
+# nanoanticuerpo
+python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/8q95_B_NA_A_CDR_3.fasta --antigen examples/pdb.files.native/8q95_B_NA_A.pdb --fasta_origin examples/fasta.files.native/8q95_B_NA_A.fasta --run_task affinity_maturation --num_samples 100
+
+# Si tiene múltiples GPUs, puede ejecutar el siguiente comando para ejecutar en paralelo
+bash scripts/multi_runs.sh
+
+# Para las secuencias generadas, puede referirse al siguiente archivo para recolectar y guardar los resultados, así como visualizarlos
+scripts/Merge_output.ipynb
+
+# Ejecutar el comando anterior generará una carpeta llamada con el ID de diseño correspondiente, que contiene lo siguiente:
+- outputs/maturation/results/8hpu_M_N_A
+- outputs/maturation/results/8hpu_M_N_A/dup # Gráfico de distribución de aminoácidos para secuencias duplicadas
+- outputs/maturation/results/8hpu_M_N_A/dup/logo.png
+- outputs/maturation/results/8hpu_M_N_A/dup/stacked_bar_chart.png
+- outputs/maturation/results/8hpu_M_N_A/original # Gráfico de distribución de aminoácidos para la secuencia original
+- outputs/maturation/results/8hpu_M_N_A/original/logo.png
+- outputs/maturation/results/8hpu_M_N_A/original/stacked_bar_chart.png
+- outputs/maturation/results/8hpu_M_N_A/dedup.csv # Resultados estadísticos para secuencias deduplicadas
+- outputs/maturation/results/8hpu_M_N_A/dedup_diff_freq.csv # Resultados estadísticos para secuencias deduplicadas (incluyendo frecuencia de generación)
+- outputs/maturation/results/8hpu_M_N_A/dup.csv # Resultados estadísticos para secuencias duplicadas
+
+# Filtrar basado en frecuencia usando outputs/maturation/results/8hpu_M_N_A/dedup_diff_freq.csv
+
+```
+
+#### Ejemplo 5: Usando IgGM para diseñar la secuencia del bucle CDR H3 para un anticuerpo y nanoanticuerpo contra un antígeno dado, y predecir la estructura general.
+```
+# anticuerpo
+python design.py --fasta examples/fasta.files.design/8hpu_M_N_A/8hpu_M_N_A_CDR_H3.fasta --antigen examples/pdb.files.native/8hpu_M_N_A.pdb
+
+# nanoanticuerpo
+python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/C8q95_B_NA_A_DR_3.fasta --antigen examples/pdb.files.native/8q95_B_NA_A.pdb
+
+```
+
+#### Ejemplo 6: Usando IgGM para diseñar las secuencias de bucle CDR para un anticuerpo y nanoanticuerpo contra un antígeno dado, y predecir la estructura general.
+```
+# anticuerpo
+python design.py --fasta examples/fasta.files.design/8hpu_M_N_A/8hpu_M_N_A_CDR_All.fasta --antigen examples/pdb.files.native/8hpu_M_N_A.pdb
+
+# nanoanticuerpo
+python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/8q95_B_NA_A_CDR_All.fasta --antigen examples/pdb.files.native/8q95_B_NA_A.pdb
+```
+
+Puede especificar otras regiones para el diseño; explore más ejemplos en la carpeta examples.
+
+#### Ejemplo 7: Diseñar secuencias de bucle CDR de anticuerpos y nanoanticuerpos y predecir la estructura general basándose solo en un antígeno y epítopo de unión dados, sin necesitar la estructura del complejo.
+* **Es posible diseñar un anticuerpo para un epítopo completamente nuevo.**
+```
+# anticuerpo
+python design.py --fasta examples/fasta.files.design/8hpu_M_N_A/8hpu_M_N_A_CDR_All.fasta --antigen examples/pdb.files.native/8hpu_M_N_A.pdb --epitope 7 8 9 10 11 12 13 14 108 109 110 111 112 113 114 115 116 118 167 157 158 160 161 162 163 164
+
+# nanoanticuerpo
+python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/8q95_B_NA_A_CDR_All.fasta --antigen examples/pdb.files.native/8q95_B_NA_A.pdb --epitope 109 110 111 112 113 114 115 116 117 120 121 140 141 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 165 166 167
+```
+Para un antígeno completamente nuevo, puede especificar epítopos para diseñar anticuerpos que puedan unirse a ellos.
+
+#### Ejemplo 8: Fusionar múltiples cadenas de antígenos en una sola cadena, especificando los IDs de las cadenas a fusionar.
+
+```
+python scripts/merge_chains.py --antigen examples/pdb.files.native/8ucd.pdb --output ./outputs --merge_ids A_B_C
+```
+
+#### Ejemplo 9: Recortar un antígeno para ahorrar memoria antes de la inferencia.
+* **¡Importante!** El epítopo debe calcularse primero (ver [Cálculo de Epítopo](#calculo-de-epitopo)). Si hay múltiples cadenas de antígenos, fusione primero (Ejemplo 8).
+* Las cadenas de anticuerpos (H/L) se conservan sin cambios; solo la cadena de antígeno especificada se recorta.
+```bash
+python scripts/trim_antigen.py --pdb outputs/8ucd_merge.pdb --fasta outputs/8ucd_merge.fasta --output outputs/8ucd_merge_trimmed.pdb --antigen-chain A --epitope 198 199 200 201 202 203 204 --keep-radius 10.0
+```
+* **--keep-radius**: (Predeterminado 10.0Å) Incluye residuos dentro de X Ångstroms del centro de masa del epítopo, asegurando que el contexto estructural se preserve incluso si los residuos son discontinuos en la secuencia. Establecer en 0 para deshabilitar.
+* Esta herramienta genera tanto PDB como FASTA recortados, e imprime los nuevos índices de epítopo renumerados para su uso en el diseño.
+
+#### Ejemplo 10: Ejecutar inferencia con un antígeno recortado y restaurar al original.
+* Este es el flujo de trabajo recomendado para antígenos grandes: Diseñar contra un parche recortado, luego restaurar automáticamente el contexto completo del antígeno y relajar el complejo final.
+```bash
+python design.py \
+    --fasta outputs/8ucd_merge_trimmed.fasta \
+    --antigen outputs/8ucd_merge_trimmed_noAb.pdb \
+    --epitope 6 7 8 9 ... (índices de la salida de recorte) \
+    --restore_merged outputs/8ucd_merge.pdb \
+    --restore_unmerged examples/pdb.files.native/8ucd.pdb \
+    --restore_IDs A_B_C \
+    --relax_open
+```
+* **--restore_merged**: El PDB usado para el recorte (proporciona el marco de referencia).
+* **--restore_unmerged**: El PDB completo original (proporciona las cadenas exactas para generar).
+* **--restore_IDs**: Los IDs de cadena del PDB original para incluir en la salida final.
+* **--relax_open**: Realiza relajación OpenMM *después* de la restauración, asegurando que la interfaz anticuerpo-antígeno se minimice energéticamente en el contexto del antígeno completo.
+
+# 🤝🏻Licencia
+
+Nuestro modelo y código se publican bajo la Licencia MIT, y pueden usarse libremente tanto para fines académicos como comerciales.
+
+Si tiene alguna pregunta, comuníquese con el equipo de IgGM en wangrubo@hotmail.com, wufandi@outlook.com.
+
+## 📋️Citar IgGM
+
+Si usa IgGM en su investigación, por favor cite nuestro trabajo.
+
+```BibTeX
+@inproceedings{
+wang2025iggm,
+title={Ig{GM}: A Generative Model for Functional Antibody and Nanobody Design},
+author={Wang, Rubo and Wu, Fandi and Gao, Xingyu and Wu, Jiaxiang and Zhao, Peilin and Yao, Jianhua},
+booktitle={The Thirteenth International Conference on Learning Representations},
+year={2025},
+url={https://openreview.net/forum?id=zmmfsJpYcq}
+}
+```
+```BibTeX
+@article {Wang2025.09.12.675771,
+	author = {Wang, Rubo and Wu, Fandi and Shi, Jiale and Song, Yidong and Kong, Yu and Ma, Jian and He, Bing and Yan, Qihong and Ying, Tianlei and Zhao, Peilin and Gao, Xingyu and Yao, Jianhua},
+	title = {A Generative Foundation Model for Antibody Design},
+	year = {2025},
+	doi = {10.1101/2025.09.12.675771},
+	publisher = {Cold Spring Harbor Laboratory},
+	URL = {https://www.biorxiv.org/content/early/2025/09/16/2025.09.12.675771},
+	journal = {bioRxiv}
+}
+```

--- a/README-pt.md
+++ b/README-pt.md
@@ -1,0 +1,282 @@
+<div align="center">
+
+# Um Modelo Computacional Generativo para Design de Anticorpos
+
+[![Homepage](http://img.shields.io/badge/Homepage-IgGM-ff88dd.svg)](https://iggm.rubo.wang)
+[![Journal Paper](http://img.shields.io/badge/Journal_paper-biorxiv-FFA876.svg)](https://www.biorxiv.org/content/10.1101/2025.09.12.675771)
+[![Conference Paper](http://img.shields.io/badge/Conference_paper-ICLR2025-6B77FE.svg)](https://openreview.net/forum?id=zmmfsJpYcq)
+[![Code License](https://img.shields.io/badge/Code%20License-MIT-green.svg)](https://github.com/TencentAI4S/IgGM/blob/master/LICENSE)
+
+
+![header](docs/IgGM_dynamic.gif)
+
+</div>
+
+
+--------------------------------------------------------------------------------
+[English](./README.md) | [简体中文](./README-zh.md) | [Español](./README-es.md) | Português
+
+## 🔊Notícias
+
+* **2025-08-22**: Acabamos de saber que nosso uso do IgGM na competição de design de anticorpos ([AIntibody: an experimentally validated in silico antibody discovery design challenge](https://www.nature.com/articles/s41587-024-02469-9)) nos rendeu um prêmio entre os três primeiros! 🎉
+* **2025-08-21**: O IgGM foi atualizado para um modelo fundamental generativo para design de anticorpos, suportando tarefas como design de novos anticorpos, maturação de afinidade, design inverso, previsão de estrutura e humanização.
+* **2025-01-15**: O IgGM foi aceito na ICLR 2025, com o artigo intitulado "IgGM: A Generative Model for Functional Antibody and Nanobody Design"🎉
+
+## 📘Introdução
+
+Este repositório contém a implementação dos dois artigos a seguir:
+
+O artigo da ICLR 2025, "IgGM: A Generative Model for Functional Antibody and Nanobody Design," introduz o IgGM, um modelo que pode projetar a estrutura geral e sequências da região CDR com base em uma sequência de estrutura (‘framework’) fornecida, e também pode projetar anticorpos para epítopos específicos.
+
+"A Generative Foundation Model for Antibody Design" estende ainda mais as capacidades do IgGM para um modelo fundamental generativo para design de anticorpos, permitindo tarefas como design de novo de anticorpos, maturação de afinidade, design inverso, previsão de estrutura e humanização.
+
+Se você tiver alguma dúvida, entre em contato com a equipe do IgGM em wangrubo@hotmail.com, wufandi@outlook.com.
+
+## 🧑🏻‍💻Começando
+
+###
+1. Clone o pacote
+```shell
+git clone https://github.com/TencentAI4S/IgGM.git
+cd IgGM
+```
+
+2. Instale o ambiente
+
+```shell
+conda env create -n IgGM -f environment.yaml
+conda activate IgGM
+pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.0.1+cu117.html
+```
+**Opcional:** 
+
+Se você precisar usar relax para a saída, instale a seguinte versão do PyRosetta:
+
+```shell
+pip install https://west.rosettacommons.org/pyrosetta/release/release/PyRosetta4.Release.python310.ubuntu.wheel/pyrosetta-2025.37+release.df75a9c48e-cp310-cp310-linux_x86_64.whl
+```
+Alternativamente, você pode usar OpenMM para relaxamento, que está incluído no environment.yaml. Use o argumento `--relax_open`.
+
+3. Baixe o modelo (Opcional, os pesos pré-treinados serão baixados automaticamente quando o código for executado)
+    * [Zenodo](https://zenodo.org/records/16909543)
+
+
+**Nota**:
+
+Se você baixar os pesos para a pasta `./checkpoints`, você poderá executar o código subsequente diretamente.
+
+Se você não baixar os pesos, eles serão baixados automaticamente quando você executar o código.
+
+## 📖Exemplos
+
+Você pode usar um arquivo fasta como entrada de sequência e um arquivo pdb como entrada de antígeno. Arquivos de exemplo estão localizados na pasta `examples`.
+
+* **Uma versão Colab do IgGM mantida por Luis pode ser encontrada em [Colab-IgGM](https://github.com/Lefrunila/Colab-IgGM), obrigado a Luis por suas contribuições!**
+
+* **Opcional:**
+  * Para todos os comandos, você pode usar PyRosetta para relaxar a saída adicionando `--relax` ou `-r`. Esta opção também adicionará átomos da cadeia lateral.
+  * Alternativamente, use `--relax_open` ou `-r_open` para usar OpenMM para relaxamento de estrutura (sem necessidade de licença PyRosetta).
+  * Para todos os comandos, você pode especificar o comprimento máximo de truncamento para o antígeno para 384 para evitar problemas de memória adicionando `--max_antigen_size 384` ou `-mas 384`.
+
+Para o processamento subsequente, você precisa preparar um arquivo fasta e um arquivo pdb. Seu arquivo fasta deve ter a seguinte estrutura, que você pode consultar na pasta `examples`.
+
+```
+>H  # ID da cadeia pesada
+VQLVESGGGLVQPGGSLRLSCAASXXXXXXXYMNWVRQAPGKGLEWVSVVXXXXXTFYTDSVKGRFTISRDNSKNTLYLQMNSLRAEDTAVYYCARXXXXXXXXXXXXXXWGQGTMVTVSS
+>L # ID da cadeia leve
+DIQMTQSPSSLSASVGDRVSITCXXXXXXXXXXXWYQQKPGKAPKLLISXXXXXXXGVPSRFSGSGSGTDFTLTITSLQPEDFATYYCXXXXXXXXXXXFGGGTKVEIK
+>A # ID do antígeno, precisa ser consistente com o arquivo pdb
+NLCPFDEVFNATRFASVYAWNRKRISNCVADYSVLYNFAPFFAFKCYGVSPTKLNDLCFTNVYADSFVIRGNEVSQIAPGQTGNIADYNYKLPDDFTGCVIAWNSNKLDSKVGGNYNYRYRLFRKSNLKPFERDISTEIYQAGNKPCNGVAGVNCYFPLQSYGFRPTYGVGHQPYRVVVLSFELLHAPATVCGP
+```
+* 'X' indica a região a ser projetada.
+* Para obter o epítopo do antígeno, você pode usar o seguinte comando:
+<a id="calculo-de-epitopo"></a>
+
+```
+python design.py --fasta examples/fasta.files.native/8iv5_A_B_G.fasta --antigen examples/pdb.files.native/8iv5_A_B_G.pdb --cal_epitope
+
+'--antigen' representa a estrutura de um complexo conhecido, e '--fasta' representa a sequência de um complexo conhecido, o que retornará o formato de epítopo necessário mais tarde, e após a cópia, o fasta pode ser substituído pela sequência que você precisa projetar. 
+
+O formato de epítopo gerado é (O número de série começa em 1): 7 8 9 10 11 12 13 14 108 109 110 111 112 113 114 115 116 118 167 
+
+Se você especificar o epítopo de acordo com a sequência, certifique-se de que a ordem da sequência seja consistente com a ordem no arquivo PDB e marque o número de série da posição correspondente.
+```
+
+#### Exemplo 1: Usando IgGM para prever estruturas de anticorpos e nanoanticorpos
+* Se o PDB contiver a estrutura do complexo, este comando gerará automaticamente informações de epítopo. Neste caso, você pode remover `--epitope`.
+```
+# anticorpo
+python design.py --fasta examples/fasta.files.native/8iv5_A_B_G.fasta --antigen examples/pdb.files.native/8iv5_A_B_G.pdb --epitope 7 8 9 10 11 12 13 14 108 109 110 111 112 113 114 115 116 118 167 157 158 160 161 162 163 164
+
+# nanoanticorpo
+python design.py --fasta examples/fasta.files.native/8q94_C_NA_A.fasta --antigen examples/pdb.files.native/8q94_C_NA_A.pdb --epitope 109 110 111 112 113 114 115 116 117 120 121 140 141 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 165 166 167
+```
+
+#### Exemplo 2: Dada a estrutura de um complexo, usar IgGM para projetar a sequência correspondente
+* Se o PDB contiver a estrutura do complexo, este comando gerará automaticamente informações de epítopo. Neste caso, você pode remover `--epitope`.
+```
+# anticorpo
+python design.py --fasta examples/fasta.files.design/8hpu_M_N_A/8hpu_M_N_A_CDR_H3.fasta --antigen examples/pdb.files.native/8hpu_M_N_A.pdb --epitope 7 8 9 10 11 12 13 14 108 109 110 111 112 113 114 115 116 118 167 157 158 160 161 162 163 164 --run_task inverse_design
+
+# nanoanticorpo
+python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/8q95_B_NA_A_CDR_H3.fasta --antigen examples/pdb.files.native/8q95_B_NA_A.pdb --epitope 109 110 111 112 113 114 115 116 117 120 121 140 141 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 165 166 167 --run_task inverse_design
+```
+
+#### Exemplo 3: Usando IgGM para redesenho de sequência de região de estrutura (framework)
+* Aqui tomamos a humanização como exemplo, o que requer [BioPhi](https://biophi.dichlab.org/humanization/humanize/).
+```
+# Anticorpo de camundongo inicial
+>H
+QVQLQESGPGLVAPSQSLSITCTVSGFSLTGYGVNWVRQPPGKGLEWLGMIWGDGNTDYNSALKSRLSISKDNSKSQVFLKMNSLHTDDTARYYCARERDYRLDYWGQGTTLTVSS
+>L
+DIVLTQSPASLSASVGETVTITCRASGNIHNYLAWYQQKQGKSPQLLVYYTTTLADGVPSRFSGSGSGTQYSLKINSLQPEDFGSYYCQHFWSTPRTFGGGTKLEIK
+>A
+KVFGRCELAAAMKRHGLDNYRGYSLGNWVCAAKFESNFNTQATNRNTDGSTDYGILQINSRWWCNDGRTPGSRNLCNIPCSALLSSDITASVNCAKKIVSDGNGMNAWVAWRNRCKGTDVQAWIRGCRL
+
+# Apenas para humanização, use BioPhi para a humanização inicial do anticorpo de camundongo
+>H
+QVQLQESGPGLVKPSETLSLTCTVSGFSLTGYGWGWIRQPPGKGLEWIGSIWGDGNTYYNPSLKSRVTISVDTSKNQFSLKLSSVTAADTAVYYCARERDYRLDYWGQGTLVTVSS
+>L
+DIQLTQSPSFLSASVGDRVTITCRASGNIHNYLAWYQQKPGKAPKLLIYYTTTLQSGVPSRFSGSGSGTEFTLTISSLQPEDFATYYCQHFWSTPRTFGGGTKVEIK
+>A
+KVFGRCELAAAMKRHGLDNYRGYSLGNWVCAAKFESNFNTQATNRNTDGSTDYGILQINSRWWCNDGRTPGSRNLCNIPCSALLSSDITASVNCAKKIVSDGNGMNAWVAWRNRCKGTDVQAWIRGCRL
+
+# Compare as diferenças entre as sequências humanizadas de diferentes regiões FR e o anticorpo de camundongo para identificar as partes que precisam de otimização. Aqui, FR1 é usado como exemplo.
+>H
+QVQLQESGPGLVXPSXXLSXTCTVSGFSLTGYGWGWIRQPPGKGLEWIGSIWGDGNTYYNPSLKSRVTISVDTSKNQFSLKLSSVTAADTAVYYCARERDYRLDYWGQGTLVTVSS
+>L
+DIQLTQSPSFLSASVGDRVTITCRASGNIHNYLAWYQQKPGKAPKLLIYYTTTLQSGVPSRFSGSGSGTEFTLTISSLQPEDFATYYCQHFWSTPRTFGGGTKVEIK
+>A
+KVFGRCELAAAMKRHGLDNYRGYSLGNWVCAAKFESNFNTQATNRNTDGSTDYGILQINSRWWCNDGRTPGSRNLCNIPCSALLSSDITASVNCAKKIVSDGNGMNAWVAWRNRCKGTDVQAWIRGCRL
+
+# Use IgGM para projetar a região FR1
+
+python design.py --fasta examples/humanization/fasta.files.design.heavy_fr1/1vfb_B_A_C.fasta --antigen examples/humanization/pdb.files.native/1vfb_B_A_C.pdb --run_task fr_design
+
+```
+
+#### Exemplo 4: Usando IgGM para maturação de afinidade de anticorpos e nanoanticorpos contra um determinado antígeno.
+```
+# anticorpo
+python design.py --fasta examples/fasta.files.design/8hpu_M_N_A/8hpu_M_N_A_CDR_H3.fasta --antigen examples/pdb.files.native/8hpu_M_N_A.pdb --fasta_origin examples/fasta.files.native/8hpu_M_N_A.fasta --run_task affinity_maturation --num_samples 100
+
+# nanoanticorpo
+python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/8q95_B_NA_A_CDR_3.fasta --antigen examples/pdb.files.native/8q95_B_NA_A.pdb --fasta_origin examples/fasta.files.native/8q95_B_NA_A.fasta --run_task affinity_maturation --num_samples 100
+
+# Se você tiver várias GPUs, pode executar o seguinte comando para executar em paralelo
+bash scripts/multi_runs.sh
+
+# Para as sequências geradas, você pode consultar o seguinte arquivo para coletar e salvar os resultados, bem como visualizá-los
+scripts/Merge_output.ipynb
+
+# Executar o comando acima gerará uma pasta nomeada com o ID de design correspondente, que contém o seguinte:
+- outputs/maturation/results/8hpu_M_N_A
+- outputs/maturation/results/8hpu_M_N_A/dup # Gráfico de distribuição de aminoácidos para sequências duplicadas
+- outputs/maturation/results/8hpu_M_N_A/dup/logo.png
+- outputs/maturation/results/8hpu_M_N_A/dup/stacked_bar_chart.png
+- outputs/maturation/results/8hpu_M_N_A/original # Gráfico de distribuição de aminoácidos para a sequência original
+- outputs/maturation/results/8hpu_M_N_A/original/logo.png
+- outputs/maturation/results/8hpu_M_N_A/original/stacked_bar_chart.png
+- outputs/maturation/results/8hpu_M_N_A/dedup.csv # Resultados estatísticos para sequências desduplicadas
+- outputs/maturation/results/8hpu_M_N_A/dedup_diff_freq.csv # Resultados estatísticos para sequências desduplicadas (incluindo frequência de geração)
+- outputs/maturation/results/8hpu_M_N_A/dup.csv # Resultados estatísticos para sequências duplicadas
+
+# Filtrar com base na frequência usando outputs/maturation/results/8hpu_M_N_A/dedup_diff_freq.csv
+
+```
+
+#### Exemplo 5: Usando IgGM para projetar a sequência do loop CDR H3 para um anticorpo e nanoanticorpo contra um determinado antígeno, e prever a estrutura geral.
+```
+# anticorpo
+python design.py --fasta examples/fasta.files.design/8hpu_M_N_A/8hpu_M_N_A_CDR_H3.fasta --antigen examples/pdb.files.native/8hpu_M_N_A.pdb
+
+# nanoanticorpo
+python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/C8q95_B_NA_A_DR_3.fasta --antigen examples/pdb.files.native/8q95_B_NA_A.pdb
+
+```
+
+#### Exemplo 6: Usando IgGM para projetar as sequências do loop CDR para um anticorpo e nanoanticorpo contra um determinado antígeno e prever a estrutura geral.
+```
+# anticorpo
+python design.py --fasta examples/fasta.files.design/8hpu_M_N_A/8hpu_M_N_A_CDR_All.fasta --antigen examples/pdb.files.native/8hpu_M_N_A.pdb
+
+# nanoanticorpo
+python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/8q95_B_NA_A_CDR_All.fasta --antigen examples/pdb.files.native/8q95_B_NA_A.pdb
+```
+
+Você pode especificar outras regiões para design; explore mais exemplos na pasta examples.
+
+#### Exemplo 7: Projetar sequências de loop CDR de anticorpos e nanoanticorpos e prever a estrutura geral com base apenas em um determinado antígeno e epítopo de ligação, sem a necessidade da estrutura do complexo.
+* **É possível projetar um anticorpo para um epítopo completamente novo.**
+```
+# anticorpo
+python design.py --fasta examples/fasta.files.design/8hpu_M_N_A/8hpu_M_N_A_CDR_All.fasta --antigen examples/pdb.files.native/8hpu_M_N_A.pdb --epitope 7 8 9 10 11 12 13 14 108 109 110 111 112 113 114 115 116 118 167 157 158 160 161 162 163 164
+
+# nanoanticorpo
+python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/8q95_B_NA_A_CDR_All.fasta --antigen examples/pdb.files.native/8q95_B_NA_A.pdb --epitope 109 110 111 112 113 114 115 116 117 120 121 140 141 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 165 166 167
+```
+Para um antígeno completamente novo, você pode especificar epítopos para projetar anticorpos que podem se ligar a eles.
+
+#### Exemplo 8: Mesclar várias cadeias de antígenos em uma única cadeia, especificando os IDs das cadeias a serem mescladas.
+
+```
+python scripts/merge_chains.py --antigen examples/pdb.files.native/8ucd.pdb --output ./outputs --merge_ids A_B_C
+```
+
+#### Exemplo 9: Recortar um antígeno para economizar memória antes da inferência.
+* **Importante!!** O epítopo deve ser calculado primeiro (veja [Cálculo de Epítopo](#calculo-de-epitopo)). Se houver várias cadeias de antígenos, mescle primeiro (Exemplo 8).
+* As cadeias de anticorpos (H/L) são preservadas inalteradas; apenas a cadeia de antígeno especificada é recortada.
+```bash
+python scripts/trim_antigen.py --pdb outputs/8ucd_merge.pdb --fasta outputs/8ucd_merge.fasta --output outputs/8ucd_merge_trimmed.pdb --antigen-chain A --epitope 198 199 200 201 202 203 204 --keep-radius 10.0
+```
+* **--keep-radius**: (Padrão 10.0Å) Inclui resíduos dentro de X Ångstroms do centro de massa do epítopo, garantindo que o contexto estrutural seja preservado mesmo se os resíduos forem descontínuos na sequência. Defina como 0 para desabilitar.
+* Esta ferramenta gera PDB e FASTA recortados e imprime os novos índices de epítopo renumerados para uso no design.
+
+#### Exemplo 10: Executar inferência com um antígeno recortado e restaurar para o original.
+* Este é o fluxo de trabalho recomendado para antígenos grandes: projetar contra um fragmento recortado, depois restaurar automaticamente o contexto completo do antígeno e relaxar o complexo final.
+```bash
+python design.py \
+    --fasta outputs/8ucd_merge_trimmed.fasta \
+    --antigen outputs/8ucd_merge_trimmed_noAb.pdb \
+    --epitope 6 7 8 9 ... (índices da saída de corte anterior) \
+    --restore_merged outputs/8ucd_merge.pdb \
+    --restore_unmerged examples/pdb.files.native/8ucd.pdb \
+    --restore_IDs A_B_C \
+    --relax_open
+```
+* **--restore_merged**: O PDB usado para o recorte (fornece o quadro de referência).
+* **--restore_unmerged**: O PDB completo original (fornece as cadeias exatas para saída).
+* **--restore_IDs**: Os IDs da cadeia do PDB original para incluir na saída final.
+* **--relax_open**: Realiza relaxamento OpenMM *após* a restauração, garantindo que a interface anticorpo-antígeno seja minimizada energeticamente no contexto do antígeno completo.
+
+# 🤝🏻Licença
+
+Nosso modelo e código são lançados sob a Licença MIT e podem ser usados livremente para fins acadêmicos e comerciais.
+
+Se você tiver alguma dúvida, entre em contato com a equipe do IgGM em wangrubo@hotmail.com, wufandi@outlook.com.
+
+## 📋️Citar IgGM
+
+Se você usar IgGM em sua pesquisa, por favor cite nosso trabalho.
+
+```BibTeX
+@inproceedings{
+wang2025iggm,
+title={Ig{GM}: A Generative Model for Functional Antibody and Nanobody Design},
+author={Wang, Rubo and Wu, Fandi and Gao, Xingyu and Wu, Jiaxiang and Zhao, Peilin and Yao, Jianhua},
+booktitle={The Thirteenth International Conference on Learning Representations},
+year={2025},
+url={https://openreview.net/forum?id=zmmfsJpYcq}
+}
+```
+```BibTeX
+@article {Wang2025.09.12.675771,
+	author = {Wang, Rubo and Wu, Fandi and Shi, Jiale and Song, Yidong and Kong, Yu and Ma, Jian and He, Bing and Yan, Qihong and Ying, Tianlei and Zhao, Peilin and Gao, Xingyu and Yao, Jianhua},
+	title = {A Generative Foundation Model for Antibody Design},
+	year = {2025},
+	doi = {10.1101/2025.09.12.675771},
+	publisher = {Cold Spring Harbor Laboratory},
+	URL = {https://www.biorxiv.org/content/early/2025/09/16/2025.09.12.675771},
+	journal = {bioRxiv}
+}
+```

--- a/README-zh.md
+++ b/README-zh.md
@@ -62,6 +62,7 @@ pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -
 ```shell
 pip install https://west.rosettacommons.org/pyrosetta/release/release/PyRosetta4.Release.python310.ubuntu.wheel/pyrosetta-2025.37+release.df75a9c48e-cp310-cp310-linux_x86_64.whl
 ```
+或者，您可以使用 OpenMM 进行弛豫（Relaxation），它包含在 environment.yaml 中。使用 `--relax_open` 参数。
 
 3. 下载模型(可选，当运行代码时，预训练权重将自动下载)
     * [Zenodo](https://zenodo.org/records/16909543)
@@ -81,6 +82,7 @@ pip install https://west.rosettacommons.org/pyrosetta/release/release/PyRosetta4
 
 * **可选：**
   * 所有命令您可以使用Pyrosetta通过添加"--relax"或"-r" 来relax输出。执行这个命令同时会添加侧链原子。
+  * 或者，使用 `--relax_open` 或 `-r_open` 使用 OpenMM 进行结构弛豫（不需要 PyRosetta 许可）。
   * 所有命令您可以通过添加"--max_antigen_size 384"或''-mas 384''来指定抗原的最大截断长度为384，以避免内存避免内存。
 
 为了方便后续处理，你需要准备一个fasta文件和一个pdb文件，你的fasta文件应该具有以下的结构，具体可以参考examples文件夹。
@@ -95,6 +97,7 @@ NLCPFDEVFNATRFASVYAWNRKRISNCVADYSVLYNFAPFFAFKCYGVSPTKLNDLCFTNVYADSFVIRGNEVSQIAPG
 ```
 * 'X'表示需要设计的区域
 * 如果需要获得抗原的表位，可以使用以下命令
+<a id="表位计算"></a>
 
 ```
 python design.py --fasta examples/fasta.files.native/8iv5_A_B_G.fasta --antigen examples/pdb.files.native/8iv5_A_B_G.pdb --cal_epitope
@@ -226,6 +229,14 @@ python design.py --fasta examples/fasta.files.design/8q95_B_NA_A/8q95_B_NA_A_CDR
 ```
 python scripts/merge_chains.py --antigen examples/pdb.files.native/8ucd.pdb --output ./outputs --merge_ids A_B_C
 ```
+
+#### 示例九: 在推理前对抗原进行修剪以节省内存。
+* **重要!!** 必须先计算表位 (请参考 [表位计算](#表位计算))。如果有多个抗原链，请先合并（示例八）。
+* 抗体链 (H/L) 保持不变；只有指定的抗原链被修剪。
+```bash
+python scripts/trim_antigen.py --pdb outputs/8ucd_merge.pdb --fasta outputs/8ucd_merge.fasta --output outputs/8ucd_merge_trimmed.pdb --antigen-chain A --epitope 198 199 200 201 202 203 204 550 553 554 555 902 904 905 906 907 908 909 910 911
+```
+该工具仅保留表位残基及其两侧各5个残基，输出修剪后的 PDB 和 FASTA 文件，并打印用于设计的重新编号表位索引。
 
 # 🤝🏻License
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -234,9 +234,27 @@ python scripts/merge_chains.py --antigen examples/pdb.files.native/8ucd.pdb --ou
 * **重要!!** 必须先计算表位 (请参考 [表位计算](#表位计算))。如果有多个抗原链，请先合并（示例八）。
 * 抗体链 (H/L) 保持不变；只有指定的抗原链被修剪。
 ```bash
-python scripts/trim_antigen.py --pdb outputs/8ucd_merge.pdb --fasta outputs/8ucd_merge.fasta --output outputs/8ucd_merge_trimmed.pdb --antigen-chain A --epitope 198 199 200 201 202 203 204 550 553 554 555 902 904 905 906 907 908 909 910 911
+python scripts/trim_antigen.py --pdb outputs/8ucd_merge.pdb --fasta outputs/8ucd_merge.fasta --output outputs/8ucd_merge_trimmed.pdb --antigen-chain A --epitope 198 199 200 201 202 203 204 --keep-radius 10.0
 ```
-该工具仅保留表位残基及其两侧各5个残基，输出修剪后的 PDB 和 FASTA 文件，并打印用于设计的重新编号表位索引。
+* **--keep-radius**: (默认 10.0Å) 包含表位质心 X 埃范围内的残基，确保即使残基在序列中不连续也能保留结构上下文。设为 0 以禁用。
+* 该工具输出修剪后的 PDB 和 FASTA 文件，并打印用于设计的重新编号表位索引。
+
+#### 示例十: 使用修剪后的抗原进行推理并恢复为原始状态。
+* 这是针对大抗原的推荐工作流程：针对修剪后的片段进行设计，然后自动恢复完整的抗原上下文并对最终复合物进行弛豫。
+```bash
+python design.py \
+    --fasta outputs/8ucd_merge_trimmed.fasta \
+    --antigen outputs/8ucd_merge_trimmed_noAb.pdb \
+    --epitope 6 7 8 9 ... (indices from trim output) \
+    --restore_merged outputs/8ucd_merge.pdb \
+    --restore_unmerged examples/pdb.files.native/8ucd.pdb \
+    --restore_IDs A_B_C \
+    --relax_open
+```
+* **--restore_merged**: 用于修剪的 PDB (提供参考坐标系)。
+* **--restore_unmerged**: 原始完整 PDB (提供最终输出的确切链)。
+* **--restore_IDs**: 原始 PDB 中需要包含在最终输出中的链 ID。
+* **--relax_open**: 在恢复*后*执行 OpenMM 弛豫，确保抗体-抗原界面在完整抗原的上下文中进行能量最小化。
 
 # 🤝🏻License
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If you need to use relax for the output, please install the following version of
 ```shell
 pip install https://west.rosettacommons.org/pyrosetta/release/release/PyRosetta4.Release.python310.ubuntu.wheel/pyrosetta-2025.37+release.df75a9c48e-cp310-cp310-linux_x86_64.whl
 ```
+Alternatively, you can use OpenMM for relaxation, which is included in the environment.yaml. Use `--relax_open` argument.
 
 3. Download the model (Optional, pretrained weights will be downloaded automatically when the code is run)
     * [Zenodo](https://zenodo.org/records/16909543)
@@ -78,6 +79,7 @@ You can use a fasta file as the sequence input and a pdb file as the antigen inp
 
 * **Optional:**
   * For all commands, you can use PyRosetta to relax the output by adding `--relax` or `-r`. This option will also add side-chain atoms.
+  * Alternatively, use `--relax_open` or `-r_open` to use OpenMM for structure relaxation (no PyRosetta license required).
   * For all commands, you can specify the maximum truncation length for the antigen to 384 to avoid memory issues by adding `--max_antigen_size 384` or `-mas 384`.
 
 For subsequent processing, you need to prepare a fasta file and a pdb file. Your fasta file should have the following structure, which you can refer to in the `examples` folder.
@@ -92,6 +94,7 @@ NLCPFDEVFNATRFASVYAWNRKRISNCVADYSVLYNFAPFFAFKCYGVSPTKLNDLCFTNVYADSFVIRGNEVSQIAPG
 ```
 * 'X' indicates the region to be designed.
 * To obtain the epitope of the antigen, you can use the following command:
+<a id="epitope-calculation"></a>
 
 ```
 python design.py --fasta examples/fasta.files.native/8iv5_A_B_G.fasta --antigen examples/pdb.files.native/8iv5_A_B_G.pdb --cal_epitope
@@ -223,6 +226,32 @@ For a completely new antigen, you can specify epitopes to design antibodies that
 ```
 python scripts/merge_chains.py --antigen examples/pdb.files.native/8ucd.pdb --output ./outputs --merge_ids A_B_C
 ```
+
+#### Example 9: Trimming an antigen to save memory before inference.
+* **Important!!** Epitope must be calculated first (see [Epitope Calculation](#epitope-calculation)). If there are multiple antigen chains, merge first (Example 8).
+* The antibody chains (H/L) are preserved unchanged; only the specified antigen chain is trimmed.
+```bash
+python scripts/trim_antigen.py --pdb outputs/8ucd_merge.pdb --fasta outputs/8ucd_merge.fasta --output outputs/8ucd_merge_trimmed.pdb --antigen-chain A --epitope 198 199 200 201 202 203 204 --keep-radius 10.0
+```
+* **--keep-radius**: (Default 10.0Å) Includes residues within X Ångstroms of the epitope's center of mass, ensuring the structural context is preserved even if residues are discontinuous in sequence. Set to 0 to disable.
+* This tool outputs both trimmed PDB and FASTA, and prints the new renumbered epitope indices for use in design.
+
+#### Example 10: Running inference with a trimmed antigen and restoring to the original.
+* This is the recommended workflow for large antigens: Design against a trimmed patch, then automatically restore the full antigen context and relax the final complex.
+```bash
+python design.py \
+    --fasta outputs/8ucd_merge_trimmed.fasta \
+    --antigen outputs/8ucd_merge_trimmed_noAb.pdb \
+    --epitope 6 7 8 9 ... (indices from trim output) \
+    --restore_merged outputs/8ucd_merge.pdb \
+    --restore_unmerged examples/pdb.files.native/8ucd.pdb \
+    --restore_IDs A_B_C \
+    --relax_open
+```
+* **--restore_merged**: The PDB used for trimming (provides the reference frame).
+* **--restore_unmerged**: The original full PDB (provides the exact chains to output).
+* **--restore_IDs**: The chain IDs from the original PDB to include in the final output.
+* **--relax_open**: Performs OpenMM relaxation *after* restoration, ensuring the antibody-antigen interface is energy-minimized in the context of the full antigen.
 
 # 🤝🏻License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 
 --------------------------------------------------------------------------------
-English | [简体中文](./README-zh.md)
+English | [简体中文](./README-zh.md) | [Español](./README-es.md) | [Português](./README-pt.md)
 ## 🔊News
 
 * **2025-08-22**: We just learned that our use of IgGM in the antibody design competition ([AIntibody: an experimentally validated in silico antibody discovery design challenge](https://www.nature.com/articles/s41587-024-02469-9)) has won us a top-three prize! 🎉

--- a/design.py
+++ b/design.py
@@ -72,6 +72,16 @@ def parse_args():
         help='relax structures after design',
     )
     parser.add_argument(
+        '--relax_open', '-r_open',
+        action='store_true',
+        help='relax structures after design using OpenMM',
+    )
+    # Restoration arguments
+    parser.add_argument('--restore_merged', type=str, default=None, help='Path to merged antigen PDB (used for alignment)')
+    parser.add_argument('--restore_unmerged', type=str, default=None, help='Path to original unmerged antigen PDB')
+    parser.add_argument('--restore_IDs', type=str, default=None, help='Chain IDs in original PDB to restore (e.g., A_B_C)')
+    parser.add_argument('--keep_trimmed', action='store_true', help='Keep trimmed sequences in restored output')
+    parser.add_argument(
         '--max_antigen_size', '-mas',
         type=int,
         default=2000,
@@ -201,14 +211,137 @@ def predict(args):
         if os.path.exists(task["output"]):
             print(f'{task["output"]} exists or has been executed by other process')
             continue
-        designer.infer_pdb(task["chains"], filename=task["output"], chunk_size=chunk_size, relax=args.relax,  temperature=temperature, task=args.run_task)
+        designer.infer_pdb(task["chains"], filename=task["output"], chunk_size=chunk_size, relax=args.relax, relax_open=args.relax_open, temperature=temperature, task=args.run_task)
 
 
 def main():
     args = parse_args()
     setup(True)
+    # Logic change: If restoration is requested, we disable generation-time relaxation
+    # and perform it AFTER restoration on the full complex.
+    do_restore = True if (args.restore_merged and args.restore_unmerged and args.restore_IDs) else False
+    
+    saved_relax = args.relax
+    saved_relax_open = args.relax_open
+    
+    if do_restore:
+        print("[Design] Restoration requested: Deferring relaxation until after restoration.")
+        args.relax = False
+        args.relax_open = False
+
     predict(args)
 
+
+    
+    # Post-inference restoration
+    if args.restore_merged and args.restore_unmerged and args.restore_IDs:
+        try:
+            print("[Restore] Starting antigen restoration...")
+            import subprocess
+            import os
+            import sys
+            
+            # Identify output files from the previous step
+            output_dir = os.path.dirname(args.output) if args.output.endswith('.pdb') else args.output
+            if not output_dir: output_dir = '.'
+            
+            # Derive base name from input FASTA
+            input_base = os.path.basename(args.fasta).replace('.fasta', '')
+            base_name = input_base
+            
+            for i in range(args.num_samples):
+                # Standard naming convention: {output_dir}/{input_base}_{i}.pdb
+                designed_pdb = f"{output_dir}/{base_name}_{i}.pdb"
+                
+                if not os.path.exists(designed_pdb):
+                     # Fallback check
+                     designed_pdb = f"{args.output}_{i}.pdb"
+                
+                if os.path.exists(designed_pdb):
+                    restored_pdb = designed_pdb.replace('.pdb', '_restored.pdb')
+                    
+                    cmd = [
+                        sys.executable,
+                        f"{os.path.dirname(os.path.abspath(__file__))}/scripts/restore_antigen.py",
+                        "--designed-pdb", designed_pdb,
+                        "--merged-pdb", args.restore_merged,
+                        "--original-pdb", args.restore_unmerged,
+                        "--restore-ids", args.restore_IDs,
+                        "--output", restored_pdb
+                    ]
+                    
+                    print(f"[Restore] Running: {' '.join(cmd)}")
+                    subprocess.check_call(cmd)
+                    
+                    # Perform Deferred Relaxation on Restricted PDB
+                    if do_restore and (saved_relax or saved_relax_open):
+                        print(f"[Restore] Relaxing restored structure: {restored_pdb}")
+                        from IgGM.utils import OpenMM_relax, Rosetta_relax
+                        
+                        if saved_relax_open:
+                            try:
+                                print(f"[Restore] Running OpenMM Relax on {restored_pdb}...")
+                                OpenMM_relax(restored_pdb)
+                                
+                                # OpenMM renames chains (A, B, C...). Restore original IDs from pre-relaxed file.
+                                # The pre-relaxed file is 'restored_pdb' before overwrite, but we overwrote it.
+                                # However, we know the chains we INTENDED: args.restore_IDs split + H + L.
+                                # Actually, easier: Read the PDB *before* relax? No, it's overwritten.
+                                # Better: OpenMM_relax could take a map? 
+                                # Best: Just renumb/rename based on the known order.
+                                # Verify order: Original Chains (A, B, C...) then Antibody (H, L).
+                                # OpenMM output: A, B, C, D, E.
+                                # Mapping: A->A, B->B, C->C, D->H, E->L.
+                                
+                                print(f"[Restore] Restoring chain IDs after OpenMM relaxation...")
+                                restored_ids = args.restore_IDs.split('_') # e.g. ['A', 'B', 'C']
+                                ab_ids = ['H', 'L'] # Standard IgGM output
+                                expected_order = restored_ids + ab_ids
+                                
+                                from Bio.PDB import PDBParser, PDBIO
+                                parser = PDBParser(QUIET=True)
+                                st = parser.get_structure("relaxed", restored_pdb)
+                                
+                                model = st[0]
+                                chains = list(model.get_chains())
+                                
+                                if len(chains) == len(expected_order):
+                                    for i, chain in enumerate(chains):
+                                        new_id = expected_order[i]
+                                        print(f"      Renaming chain {chain.id} -> {new_id}")
+                                        chain.id = new_id
+                                        
+                                    io = PDBIO()
+                                    io.set_structure(st)
+                                    io.save(restored_pdb)
+                                    print(f"[Restore] Chain IDs restored in {restored_pdb}")
+                                else:
+                                    print(f"      ⚠️ Warning: Chain count mismatch (Found {len(chains)}, Expected {len(expected_order)}). Skipping rename.")
+                                    
+                            except Exception as e:
+                                print(f"[Restore] OpenMM Relax/Rename failed: {e}")
+                                
+                        if saved_relax:
+                            try:
+                                print(f"[Restore] Running Rosetta Relax on {restored_pdb}...")
+                                # Rosetta_relax usually overwrites or creates a numbered suffix? 
+                                # IgGM.utils.Rosetta_relax implementation:
+                                # def Rosetta_relax(pdb_file): ... tries to relax and overwrite/save.
+                                Rosetta_relax(restored_pdb)
+                            except Exception as e:
+                                print(f"[Restore] Rosetta Relax failed: {e}")
+                    
+                    # Delete trimmed output if not keeping
+                    if not args.keep_trimmed:
+                        print(f"[Restore] Deleting trimmed output: {designed_pdb}")
+                        os.remove(designed_pdb)
+                        # Also remove fasta if exists
+                        designed_fasta = designed_pdb.replace('.pdb', '.fasta')
+                        if os.path.exists(designed_fasta):
+                            os.remove(designed_fasta)
+                            
+        except Exception as e:
+            print(f"[Restore] Error during restoration: {e}")
 
 if __name__ == '__main__':
     main()

--- a/design.py
+++ b/design.py
@@ -283,15 +283,9 @@ def main():
                                 print(f"[Restore] Running OpenMM Relax on {restored_pdb}...")
                                 OpenMM_relax(restored_pdb)
                                 
-                                # OpenMM renames chains (A, B, C...). Restore original IDs from pre-relaxed file.
-                                # The pre-relaxed file is 'restored_pdb' before overwrite, but we overwrote it.
-                                # However, we know the chains we INTENDED: args.restore_IDs split + H + L.
-                                # Actually, easier: Read the PDB *before* relax? No, it's overwritten.
-                                # Better: OpenMM_relax could take a map? 
-                                # Best: Just renumb/rename based on the known order.
-                                # Verify order: Original Chains (A, B, C...) then Antibody (H, L).
-                                # OpenMM output: A, B, C, D, E.
-                                # Mapping: A->A, B->B, C->C, D->H, E->L.
+                                # OpenMM/PDBFixer often renames chains (A, B, C...). 
+                                # We restore the original chain IDs (Antigen chains + H + L) based on the known input order.
+                                # Assumes OpenMM preserves the order of chains.
                                 
                                 print(f"[Restore] Restoring chain IDs after OpenMM relaxation...")
                                 restored_ids = args.restore_IDs.split('_') # e.g. ['A', 'B', 'C']
@@ -316,7 +310,7 @@ def main():
                                     io.save(restored_pdb)
                                     print(f"[Restore] Chain IDs restored in {restored_pdb}")
                                 else:
-                                    print(f"      ⚠️ Warning: Chain count mismatch (Found {len(chains)}, Expected {len(expected_order)}). Skipping rename.")
+                                    print(f"      [WARNING] Chain count mismatch (Found {len(chains)}, Expected {len(expected_order)}). Skipping rename.")
                                     
                             except Exception as e:
                                 print(f"[Restore] OpenMM Relax/Rename failed: {e}")

--- a/scripts/merge_chains.py
+++ b/scripts/merge_chains.py
@@ -5,13 +5,15 @@ import os
 import sys
 from collections import OrderedDict
 
+# Finds the root directory (one level up from this script's folder)
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.append(ROOT_DIR)
+
 import torch
 import tqdm
 
 from IgGM.protein import export_fasta
-
-sys.path.append('.')
-
 from IgGM.protein.parser import parse_fasta, PdbParser
 
 

--- a/scripts/restore_antigen.py
+++ b/scripts/restore_antigen.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+"""
+Antigen Restoration Tool.
+
+Aligns the designed antibody back to the full, original antigen structure by calculating
+structural alignment between the trimmed design antigen and the original antigen.
+
+Flow:
+1. Align Designed_Antigen -> Merged_Antigen (T1)
+2. Align Merged_Antigen -> Original_Antigen (T2)
+3. Apply T = T2 * T1 to Antibody chains
+4. Save Antibody + Original Antigen
+
+Usage:
+    python restore_antigen.py ...
+"""
+
+import os
+import sys
+import argparse
+import numpy as np
+from Bio import pairwise2
+from Bio.PDB import PDBParser, Superimposer, PDBIO, Select
+
+def get_chain_data(structure, chain_id):
+    """Extract CA atoms and Sequence for a chain."""
+    atoms = []
+    seq = ""
+    # simple 3->1
+    aa_map = {'ALA':'A','CYS':'C','ASP':'D','GLU':'E','PHE':'F','GLY':'G','HIS':'H','ILE':'I','LYS':'K','LEU':'L','MET':'M','ASN':'N','PRO':'P','GLN':'Q','ARG':'R','SER':'S','THR':'T','VAL':'V','TRP':'W','TYR':'Y'}
+    
+    for model in structure:
+        for chain in model:
+            if chain.id == chain_id:
+                for residue in chain:
+                    if 'CA' in residue:
+                        atoms.append(residue['CA'])
+                        seq += aa_map.get(residue.resname, 'X')
+    return atoms, seq
+
+def get_all_ca_atoms(structure, chain_ids=None):
+    """Get all CA atoms for specified chains (or all if None)."""
+    atoms = []
+    for model in structure:
+        for chain in model:
+            if chain_ids is None or chain.id in chain_ids:
+                for residue in chain:
+                    if 'CA' in residue:
+                        atoms.append(residue['CA'])
+    return atoms
+
+def align_subsequence(query_atoms, query_seq, target_atoms, target_seq):
+    """
+    Find best alignment of query within target and return paired atoms.
+    Assumes query is a subset of target (gaps in target not allowed in matching region, but gaps in query ok if trimmed discontinuous?)
+    Actually trim_antigen produces discontinuous segments? 
+    It produces "epitope + 5 neighbors". This might be disjoint.
+    So we align sequences allowing gaps in TARGET to skip over non-trimmed regions.
+    GAP_OPEN = -10, GAP_EXTEND = -0.5
+    """
+    # Force query to match fully (no gaps in query) if possible? No, query is just residues.
+    # We want local alignment.
+    
+    # alignments = pairwise2.align.localds(target_seq, query_seq, 5, -5, -10, -0.5) 
+    # Use simple exact matching logic if sequences are identical subset.
+    # Because design process shouldn't mutate antigen sequence (usually).
+    
+    # Let's try explicit mapping by exact residues.
+    # Query must be a subsequence of Target.
+    
+    # Since alignment is potentially discontinuous, simplistic "find substring" fails.
+    # Biopython pairwise2 is good.
+    # Maximize matches.
+    # Match +5, Mismatch -5, Gap -10.
+    
+    alignments = pairwise2.align.globalms(target_seq, query_seq, 5, -5, -10, -0.5)
+    best = alignments[0]
+    aligned_target, aligned_query, _, _, _ = best
+    
+    # Map atoms
+    # Iterate through alignment.
+    # If both align (not '-'), map target_atom[i] <-> query_atom[j]
+    
+    target_indices = []
+    query_indices = []
+    
+    t_idx = 0
+    q_idx = 0
+    
+    valid_pairs_target = []
+    valid_pairs_query = []
+    
+    for t_char, q_char in zip(aligned_target, aligned_query):
+        if t_char != '-':
+            curr_t_atom = target_atoms[t_idx] if t_idx < len(target_atoms) else None
+            t_idx += 1
+        else:
+            curr_t_atom = None
+            
+        if q_char != '-':
+            curr_q_atom = query_atoms[q_idx] if q_idx < len(query_atoms) else None
+            q_idx += 1
+        else:
+            curr_q_atom = None
+            
+        if t_char != '-' and q_char != '-' and t_char == q_char:
+            valid_pairs_target.append(curr_t_atom)
+            valid_pairs_query.append(curr_q_atom)
+            
+    return valid_pairs_query, valid_pairs_target # Matching pair lists
+
+def main():
+    parser = argparse.ArgumentParser(description="IgGM Antigen Restoration Post-Inference")
+    parser.add_argument('--designed-pdb', required=True, help="Input designed PDB (trimmed Ag + Ab)")
+    parser.add_argument('--merged-pdb', required=True, help="Merged PDB used for design")
+    parser.add_argument('--original-pdb', required=True, help="Original full PDB")
+    parser.add_argument('--output', required=True, help="Output restored PDB")
+    parser.add_argument('--antigen-chain', default="A", help="Chain ID of antigen in design/merged")
+    parser.add_argument('--restore-ids', required=True, help="Chain IDs in original PDB to preserve")
+    
+    args = parser.parse_args()
+    
+    pdb_parser = PDBParser(QUIET=True)
+    
+    print(f"Loading structures...")
+    design_st = pdb_parser.get_structure('design', args.designed_pdb)
+    merged_st = pdb_parser.get_structure('merged', args.merged_pdb)
+    original_st = pdb_parser.get_structure('original', args.original_pdb)
+    
+    # === Step 1: Align Designed -> Merged ===
+    print("\n--- Alignment 1: Designed -> Merged ---")
+    
+    # Get atoms/seq for trimmed antigen in Design
+    d_atoms, d_seq = get_chain_data(design_st, args.antigen_chain)
+    print(f"Designed Antigen (Chain {args.antigen_chain}): {len(d_atoms)} atoms, {len(d_seq)} residues")
+    
+    # Get atoms/seq for full antigen in Merged
+    # Assuming merged antigen is also 'A'? Usually merge_chains makes it 'A'.
+    # If merged was multi-chain, trim_antigen usually takes 'A'.
+    m_atoms, m_seq = get_chain_data(merged_st, args.antigen_chain)
+    print(f"Merged Antigen (Chain {args.antigen_chain}): {len(m_atoms)} atoms, {len(m_seq)} residues")
+    
+    # Find alignment
+    # If d_atoms is subset of m_atoms
+    pairs_d, pairs_m = align_subsequence(d_atoms, d_seq, m_atoms, m_seq)
+    print(f"Matched {len(pairs_d)} residues between Designed and Merged")
+    
+    if len(pairs_d) < 3:
+        print("Error: Insufficient matching residues for alignment (<3)")
+        sys.exit(1)
+        
+    # Calculate T1 (Designed -> Merged)
+    sup1 = Superimposer()
+    sup1.set_atoms(pairs_m, pairs_d) # Fixed, Moving
+    # Apply transform to Design structure (moves Ab to Merged frame)
+    print(f"Applying T1 (RMSD: {sup1.rms:.3f})...")
+    sup1.apply(design_st.get_atoms())
+    
+    
+    # === Step 2: Align Merged -> Original ===
+    print("\n--- Alignment 2: Merged -> Original ---")
+    
+    # We need to map Merged chain 'A' to Original chains (restore_ids)
+    # Merged 'A' is usually concatenation of Original chains.
+    # We can align Merged 'A' (which is now our reference for Design) to Original chains combined.
+    
+    # Actually, simpler:
+    # Use the same matching logic. Merged sequence ~ Concatenation of Original Sequences.
+    # Or just align common subset.
+    
+    orig_chain_ids = args.restore_ids.split('_')
+    print(f"Original chains: {orig_chain_ids}")
+    
+    o_atoms = get_all_ca_atoms(original_st, orig_chain_ids)
+    # Get sequence for all original CA atoms (might be discontinuous across chains, flattened)
+    o_seq = ""
+    aa_map = {'ALA':'A','CYS':'C','ASP':'D','GLU':'E','PHE':'F','GLY':'G','HIS':'H','ILE':'I','LYS':'K','LEU':'L','MET':'M','ASN':'N','PRO':'P','GLN':'Q','ARG':'R','SER':'S','THR':'T','VAL':'V','TRP':'W','TYR':'Y'}
+    for atom in o_atoms:
+        o_seq += aa_map.get(atom.get_parent().resname, 'X')
+        
+    print(f"Original Antigen (Chains {args.restore_ids}): {len(o_atoms)} atoms")
+    
+    # Align Merged (Moving) -> Original (Fixed)
+    # Wait, Merged is our current frame (where Ab is now). 
+    # We need to move Merged frame to Original frame.
+    # So T2: Merged -> Original.
+    
+    # Pairs between Merged and Original
+    # Merged should be identical to Original (just merged chains).
+    # Sequences should match.
+    # Let's align m_seq (subset of original? or original is subset?)
+    # Usually merged = original.
+    
+    pairs_m2, pairs_o = align_subsequence(m_atoms, m_seq, o_atoms, o_seq)
+    print(f"Matched {len(pairs_m2)} residues between Merged and Original")
+    
+    if len(pairs_m2) < 3:
+        print("Error: Insufficient match for Merged->Original alignment")
+        # Proceed with identity? Warn user.
+        pass
+    else:
+        sup2 = Superimposer()
+        sup2.set_atoms(pairs_o, pairs_m2) # Fixed, Moving
+        print(f"Applying T2 (RMSD: {sup2.rms:.3f})...")
+        # Apply T2 to Design structure (which is already in Merged frame)
+        sup2.apply(design_st.get_atoms())
+        
+        
+    # === Step 3: Assembly ===
+    print("\n--- Assembly ---")
+    # Identify Antibody chains from Design (those != antigen_chain)
+    ab_chains = [c for c in design_st[0] if c.id != args.antigen_chain]
+    print(f"Antibody chains to save: {[c.id for c in ab_chains]}")
+    
+    # Identify Original chains
+    orig_chains = [c for c in original_st[0] if c.id in orig_chain_ids]
+    
+    # Build output
+    io = PDBIO()
+    
+    class OutputSelect(Select):
+        def accept_chain(self, chain):
+            return True
+            
+    # HACK: construct a temporary structure for output
+    # Since we can't easily merge structures with Bio.PDB (parent pointers),
+    # we copy chains to a new Model/Structure
+    from Bio.PDB.Structure import Structure
+    from Bio.PDB.Model import Model
+    
+    out_st = Structure('output')
+    out_model = Model(0)
+    out_st.add(out_model)
+    
+    # Add Original Chains (A, B, C...)
+    # They are already in correct frame (Fixed)
+    for c in orig_chains:
+        out_model.add(c.copy())
+        
+    # Add Antibody Chains (H, L...)
+    # They have been transformed (T2 * T1)
+    for c in ab_chains:
+        out_model.add(c.copy())
+        
+    print(f"Saving to {args.output}...")
+    io.set_structure(out_st)
+    io.save(args.output)
+    
+    # FASTA
+    output_fasta = args.output.replace('.pdb', '.fasta')
+    with open(output_fasta, 'w') as f:
+        for chain in out_model:
+            seq = ""
+            for res in chain:
+                if 'CA' in res:
+                    seq += aa_map.get(res.resname, 'X')
+            f.write(f">{chain.id}\n{seq}\n")
+    print("Done.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/restore_antigen.py
+++ b/scripts/restore_antigen.py
@@ -26,7 +26,7 @@ def get_chain_data(structure, chain_id):
     """Extract CA atoms and Sequence for a chain."""
     atoms = []
     seq = ""
-    # simple 3->1
+    # Map 3-letter codes to 1-letter codes
     aa_map = {'ALA':'A','CYS':'C','ASP':'D','GLU':'E','PHE':'F','GLY':'G','HIS':'H','ILE':'I','LYS':'K','LEU':'L','MET':'M','ASN':'N','PRO':'P','GLN':'Q','ARG':'R','SER':'S','THR':'T','VAL':'V','TRP':'W','TYR':'Y'}
     
     for model in structure:
@@ -51,27 +51,12 @@ def get_all_ca_atoms(structure, chain_ids=None):
 
 def align_subsequence(query_atoms, query_seq, target_atoms, target_seq):
     """
-    Find best alignment of query within target and return paired atoms.
-    Assumes query is a subset of target (gaps in target not allowed in matching region, but gaps in query ok if trimmed discontinuous?)
-    Actually trim_antigen produces discontinuous segments? 
-    It produces "epitope + 5 neighbors". This might be disjoint.
-    So we align sequences allowing gaps in TARGET to skip over non-trimmed regions.
-    GAP_OPEN = -10, GAP_EXTEND = -0.5
+    Find best local alignment of query within target and return paired atoms.
+    
+    This handles potential gaps or discontinuous segments (e.g., radius-trimmed antigens).
+    Uses Biopython's pairwise2 local alignment (match=+5, mismatch=-5, gap_open=-10, gap_extend=-0.5).
     """
-    # Force query to match fully (no gaps in query) if possible? No, query is just residues.
-    # We want local alignment.
-    
-    # alignments = pairwise2.align.localds(target_seq, query_seq, 5, -5, -10, -0.5) 
-    # Use simple exact matching logic if sequences are identical subset.
-    # Because design process shouldn't mutate antigen sequence (usually).
-    
-    # Let's try explicit mapping by exact residues.
-    # Query must be a subsequence of Target.
-    
-    # Since alignment is potentially discontinuous, simplistic "find substring" fails.
-    # Biopython pairwise2 is good.
-    # Maximize matches.
-    # Match +5, Mismatch -5, Gap -10.
+    # Perform local alignment to identifying matching subsequences using a robust scoring scheme.
     
     alignments = pairwise2.align.globalms(target_seq, query_seq, 5, -5, -10, -0.5)
     best = alignments[0]
@@ -134,9 +119,8 @@ def main():
     d_atoms, d_seq = get_chain_data(design_st, args.antigen_chain)
     print(f"Designed Antigen (Chain {args.antigen_chain}): {len(d_atoms)} atoms, {len(d_seq)} residues")
     
-    # Get atoms/seq for full antigen in Merged
-    # Assuming merged antigen is also 'A'? Usually merge_chains makes it 'A'.
-    # If merged was multi-chain, trim_antigen usually takes 'A'.
+    # Get atoms/seq for full antigen in Merged structure.
+    # The merged antigen is typically assigned chain 'A' during the preprocessing step.
     m_atoms, m_seq = get_chain_data(merged_st, args.antigen_chain)
     print(f"Merged Antigen (Chain {args.antigen_chain}): {len(m_atoms)} atoms, {len(m_seq)} residues")
     
@@ -160,13 +144,8 @@ def main():
     # === Step 2: Align Merged -> Original ===
     print("\n--- Alignment 2: Merged -> Original ---")
     
-    # We need to map Merged chain 'A' to Original chains (restore_ids)
-    # Merged 'A' is usually concatenation of Original chains.
-    # We can align Merged 'A' (which is now our reference for Design) to Original chains combined.
-    
-    # Actually, simpler:
-    # Use the same matching logic. Merged sequence ~ Concatenation of Original Sequences.
-    # Or just align common subset.
+    # Map residues from the Merged antigen (referenced as Chain A) to the Original multi-chain structure.
+    # Since the Merged sequence is a concatenation of the Original sequences, we align them to establish the coordinate transform.
     
     orig_chain_ids = args.restore_ids.split('_')
     print(f"Original chains: {orig_chain_ids}")
@@ -180,16 +159,8 @@ def main():
         
     print(f"Original Antigen (Chains {args.restore_ids}): {len(o_atoms)} atoms")
     
-    # Align Merged (Moving) -> Original (Fixed)
-    # Wait, Merged is our current frame (where Ab is now). 
-    # We need to move Merged frame to Original frame.
-    # So T2: Merged -> Original.
-    
-    # Pairs between Merged and Original
-    # Merged should be identical to Original (just merged chains).
-    # Sequences should match.
-    # Let's align m_seq (subset of original? or original is subset?)
-    # Usually merged = original.
+    # Align Merged (Moving) -> Original (Fixed) to calculate Transformation T2.
+    # This transforms coordinates from the Merged frame to the Original PDB frame.
     
     pairs_m2, pairs_o = align_subsequence(m_atoms, m_seq, o_atoms, o_seq)
     print(f"Matched {len(pairs_m2)} residues between Merged and Original")
@@ -222,9 +193,8 @@ def main():
         def accept_chain(self, chain):
             return True
             
-    # HACK: construct a temporary structure for output
-    # Since we can't easily merge structures with Bio.PDB (parent pointers),
-    # we copy chains to a new Model/Structure
+    # Construct a new Structure object for the final output.
+    # This approach avoids issues with modifying existing Structure/Model parent pointers in Biopython.
     from Bio.PDB.Structure import Structure
     from Bio.PDB.Model import Model
     

--- a/scripts/trim_antigen.py
+++ b/scripts/trim_antigen.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python
+"""
+Standalone Antigen Trimming Tool.
+
+Trims the specified antigen chain to epitope residues +/- neighborhood window.
+All other chains (e.g., antibody H/L) are preserved unchanged.
+Outputs both trimmed PDB and FASTA with renumbered antigen residues.
+
+IMPORTANT: Epitope indices should be the same PDB residue numbers output by --cal_epitope.
+
+Usage:
+    python trim_antigen.py --pdb complex.pdb --fasta complex.fasta --output trimmed.pdb --antigen-chain A --epitope 198 199 200 --neighborhood 5
+"""
+
+import os
+import sys
+import argparse
+
+# Add repo root to path to import IgGM
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.append(ROOT_DIR)
+
+# Standard amino acid 3->1 letter mapping
+AA_3TO1 = {
+    'ALA': 'A', 'CYS': 'C', 'ASP': 'D', 'GLU': 'E', 'PHE': 'F',
+    'GLY': 'G', 'HIS': 'H', 'ILE': 'I', 'LYS': 'K', 'LEU': 'L',
+    'MET': 'M', 'ASN': 'N', 'PRO': 'P', 'GLN': 'Q', 'ARG': 'R',
+    'SER': 'S', 'THR': 'T', 'VAL': 'V', 'TRP': 'W', 'TYR': 'Y',
+}
+
+def parse_pdb_by_chain(pdb_file):
+    """
+    Parse a PDB file and extract residues organized by chain.
+    Returns dict: {chain_id: [{'resnum': int, 'resname': str, 'atoms': [lines]}]}
+    """
+    chains = {}
+    current_res = None
+    current_chain = None
+    
+    with open(pdb_file, 'r') as f:
+        for line in f:
+            if line.startswith('ATOM') or line.startswith('HETATM'):
+                chain = line[21]
+                res_num = int(line[22:26].strip())
+                res_name = line[17:20].strip()
+                
+                if chain not in chains:
+                    chains[chain] = []
+                
+                if current_chain != chain or current_res is None or current_res['resnum'] != res_num:
+                    # New residue or new chain
+                    if current_res is not None and current_chain is not None:
+                        chains[current_chain].append(current_res)
+                    current_res = {
+                        'resnum': res_num,
+                        'resname': res_name,
+                        'atoms': [line]
+                    }
+                    current_chain = chain
+                else:
+                    current_res['atoms'].append(line)
+    
+    # Don't forget the last residue
+    if current_res is not None and current_chain is not None:
+        chains[current_chain].append(current_res)
+    
+    return chains
+
+import math
+
+def get_residue_ca(atom_lines):
+    """Extract CA coordinate from atom lines. Returns (x, y, z) or None."""
+    for line in atom_lines:
+        if line[12:16].strip() == 'CA':
+            x = float(line[30:38])
+            y = float(line[38:46])
+            z = float(line[46:54])
+            return (x, y, z)
+    return None
+
+def trim_residues(residues, epitope_pdb_nums, neighborhood_size=5, keep_radius=0.0):
+    """
+    Trim residues to keep only epitope + neighborhood, PLUS residues within radius of CoM.
+    Returns list of kept residues and the new renumbered epitope indices.
+    """
+    # Build mapping from resnum to sequential index
+    all_resnums = [r['resnum'] for r in residues]
+    resnum_to_idx = {num: idx for idx, num in enumerate(all_resnums)}
+    
+    # 1. Identify Seed Residues (Epitope + Neighborhood)
+    seed_indices = set()
+    for epi_num in epitope_pdb_nums:
+        if epi_num in resnum_to_idx:
+            idx = resnum_to_idx[epi_num]
+            # Keep residues within neighborhood
+            for i in range(max(0, idx - neighborhood_size), min(len(residues), idx + neighborhood_size + 1)):
+                seed_indices.add(i)
+    
+    final_indices = seed_indices.copy()
+    
+    # 2. Radius Expansion (if enabled)
+    if keep_radius > 0 and seed_indices:
+        # Calculate CoM of seed residues
+        seed_coords = []
+        for idx in seed_indices:
+            coord = get_residue_ca(residues[idx]['atoms'])
+            if coord:
+                seed_coords.append(coord)
+        
+        if seed_coords:
+            n_seeds = len(seed_coords)
+            com_x = sum(c[0] for c in seed_coords) / n_seeds
+            com_y = sum(c[1] for c in seed_coords) / n_seeds
+            com_z = sum(c[2] for c in seed_coords) / n_seeds
+            
+            print(f"  Center of Mass of seed residues: ({com_x:.1f}, {com_y:.1f}, {com_z:.1f})")
+            print(f"  Expanding selection with radius {keep_radius}A...")
+            
+            # Check all residues
+            sq_radius = keep_radius ** 2
+            added_count = 0
+            for i, res in enumerate(residues):
+                if i in final_indices:
+                    continue
+                
+                coord = get_residue_ca(res['atoms'])
+                if coord:
+                    dist_sq = (coord[0]-com_x)**2 + (coord[1]-com_y)**2 + (coord[2]-com_z)**2
+                    if dist_sq <= sq_radius:
+                        final_indices.add(i)
+                        added_count += 1
+            print(f"    Added {added_count} residues from radius check.")
+    
+    # Get residues to keep (in order)
+    kept_residues = [residues[i] for i in sorted(final_indices)]
+    
+    # Calculate new epitope indices (1-based)
+    kept_resnums = {r['resnum'] for r in kept_residues}
+    new_epitope = []
+    for new_idx, res in enumerate(kept_residues):
+        if res['resnum'] in epitope_pdb_nums:
+            new_epitope.append(new_idx + 1)
+    
+    return kept_residues, new_epitope
+
+def write_pdb(chains_data, output_file, chain_order=None):
+    """
+    Write chains to PDB file.
+    chains_data: dict {chain_id: [residues]}
+    chain_order: optional list specifying order of chains
+    """
+    if chain_order is None:
+        chain_order = sorted(chains_data.keys())
+    
+    with open(output_file, 'w') as f:
+        atom_num = 1
+        for chain_id in chain_order:
+            if chain_id not in chains_data:
+                continue
+            residues = chains_data[chain_id]
+            for new_resnum, res in enumerate(residues, start=1):
+                for atom_line in res['atoms']:
+                    # Renumber atoms and residues
+                    new_line = (
+                        atom_line[:6] +
+                        f'{atom_num:5d}' +
+                        atom_line[11:21] +
+                        chain_id +
+                        f'{new_resnum:4d}' +
+                        atom_line[26:]
+                    )
+                    f.write(new_line)
+                    atom_num += 1
+            f.write('TER\n')
+        f.write('END\n')
+
+def write_fasta(chains_data, output_file, chain_order=None):
+    """Write all chains to FASTA file."""
+    if chain_order is None:
+        chain_order = sorted(chains_data.keys())
+    
+    with open(output_file, 'w') as f:
+        for chain_id in chain_order:
+            if chain_id not in chains_data:
+                continue
+            residues = chains_data[chain_id]
+            seq = ''.join(AA_3TO1.get(r['resname'], 'X') for r in residues)
+            f.write(f'>{chain_id}\n{seq}\n')
+
+def main():
+    parser = argparse.ArgumentParser(description="IgGM Antigen Trimmer - trims antigen while preserving other chains")
+    parser.add_argument('--pdb', required=True, help="Input complex PDB file")
+    parser.add_argument('--fasta', required=True, help="Input FASTA file (for reference)")
+    parser.add_argument('--output', required=True, help="Output trimmed complex PDB")
+    parser.add_argument('--antigen-chain', type=str, default="A", help="Antigen Chain ID to trim (default A)")
+    parser.add_argument('--neighborhood', type=int, default=5, help="Residues to keep on each side (default 5)")
+    parser.add_argument('--keep-radius', type=float, default=25.0, help="Keep residues within this radius (A) of selection CoM (default 25.0)")
+    parser.add_argument('--epitope', nargs='+', type=int, required=True, help="Epitope PDB residue numbers from --cal_epitope")
+    
+    args = parser.parse_args()
+    
+    # Derive output FASTA path
+    output_fasta = args.output.replace('.pdb', '.fasta')
+    
+    # 1. Parse all chains from PDB
+    print(f"Parsing PDB: {args.pdb}")
+    chains = parse_pdb_by_chain(args.pdb)
+    print(f"Found chains: {list(chains.keys())}")
+    
+    for chain_id, residues in chains.items():
+        print(f"  Chain {chain_id}: {len(residues)} residues (PDB range: {residues[0]['resnum']} to {residues[-1]['resnum']})")
+    
+    # 2. Validate antigen chain exists
+    antigen_chain = args.antigen_chain
+    if antigen_chain not in chains:
+        print(f"ERROR: Antigen chain '{antigen_chain}' not found in PDB!")
+        print(f"Available chains: {list(chains.keys())}")
+        sys.exit(1)
+    
+    antigen_residues = chains[antigen_chain]
+    
+    # 3. Validate epitope residues
+    epitope_set = set(args.epitope)
+    resnum_set = {r['resnum'] for r in antigen_residues}
+    valid_epitope = [e for e in args.epitope if e in resnum_set]
+    missing = [e for e in args.epitope if e not in resnum_set]
+    
+    if missing:
+        print(f"WARNING: These epitope residues not found in chain {antigen_chain}: {missing}")
+    
+    if not valid_epitope:
+        print("ERROR: No valid epitope residues found in antigen chain!")
+        sys.exit(1)
+    
+    print(f"\nTrimming antigen chain {antigen_chain}:")
+    print(f"  Epitope residues: {' '.join(map(str, valid_epitope))}")
+    print(f"  Neighborhood: ±{args.neighborhood} residues")
+    
+    # 4. Trim antigen
+    trimmed_antigen, new_epitope = trim_residues(antigen_residues, valid_epitope, args.neighborhood, args.keep_radius)
+    print(f"  Trimmed: {len(antigen_residues)} → {len(trimmed_antigen)} residues")
+    
+    # 5. Build output chains (preserve all, replace antigen with trimmed version)
+    output_chains = {}
+    for chain_id, residues in chains.items():
+        if chain_id == antigen_chain:
+            output_chains[chain_id] = trimmed_antigen
+        else:
+            output_chains[chain_id] = residues
+    
+    # Determine chain order (put antigen last, as is convention)
+    other_chains = [c for c in chains.keys() if c != antigen_chain]
+    chain_order = sorted(other_chains) + [antigen_chain]
+    
+    # 6. Save PDB (with all chains)
+    print(f"\nSaving trimmed PDB to {args.output}...")
+    write_pdb(output_chains, args.output, chain_order)
+    
+    # 7. Save FASTA (with all chains)
+    print(f"Saving FASTA to {output_fasta}...")
+    write_fasta(output_chains, output_fasta, chain_order)
+    
+    # 8. Save antigen-only version (_noAb.pdb)
+    output_noab_pdb = args.output.replace('.pdb', '_noAb.pdb')
+    antigen_only = {antigen_chain: trimmed_antigen}
+    
+    print(f"Saving antigen-only PDB to {output_noab_pdb}...")
+    write_pdb(antigen_only, output_noab_pdb, [antigen_chain])
+    
+    # Summary
+    print(f"\nOutput summary:")
+    for chain_id in chain_order:
+        residues = output_chains[chain_id]
+        seq = ''.join(AA_3TO1.get(r['resname'], 'X') for r in residues)
+        status = "(TRIMMED)" if chain_id == antigen_chain else "(unchanged)"
+        print(f"  Chain {chain_id}: {len(residues)} aa {status}")
+    
+    print(f"\nNew epitope indices for design: {' '.join(map(str, new_epitope))}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I have added the option to relax using OpenMM, keeping the entire design pipeline Open Source.

I have also added a new feature: Antigen trimming, this allows inference to run only with epitope residues plus 5 neighbors per each. Including additional residues within a radius defined  by the epitope's center of mass can be done too.

A restoration script is available to restore the trimmed antigen to its full original size after inference. 

This significantly reduces inference time and memory usage, most antigens can be used for nanobody design with a 6 Gb GPU and 8 Gb for antibody design.


_Note on Binding Pose Accuracy_: In my test runs, I observed that the predicted binding poses sometimes differ significantly from the ground truth structures. Importantly, this occurs even with untrimmed antigens, suggesting it may be related to model parameterization or sampling rather than the trimming feature itself. I have included my test outputs `(test_runs_outputs.tar.gz) `for the authors to review and investigate this behavior.

[test_runs_outputs.tar.gz](https://github.com/user-attachments/files/24425059/test_runs_outputs.tar.gz)
